### PR TITLE
Require explicit general database closing.

### DIFF
--- a/leveldb/doc.go
+++ b/leveldb/doc.go
@@ -9,6 +9,11 @@
 // Create or open a database:
 //
 //	db, err := leveldb.OpenFile("path/to/db", &opt.Options{Flag: opt.OFCreateIfMissing})
+//	if err != nil {
+//		log.Println("could not open database:", err)
+//		return
+//	}
+//	defer db.Close()
 //	...
 //
 // Read or modify the database content:


### PR DESCRIPTION
To be idiomatic and play nicely as a library, control of the database
should exist solely in the hands of the library user and not in that
of the memory manager.

Major Caveat: A number of internal types around iterators and versions
retain their finalizers for now.  I need to take some time to diagram
their lifecycle to propose a solution for this.  This domain is where,
I believe, the nondeterminism I found was, but I want to start fixing
the easy part first.

@syndtr, if you have some recommendations for
how to approach this, I would love to talk with you.  If you look at other
LevelDB implementations, they explicitly require the user to call
`Iterator.Close` to free associated resources, including the an
official but incomplete implementation from Google in Go at
https://code.google.com/p/leveldb-go/source/browse/leveldb/db/db.go#72.
