### PR TITLE
storage: fix plan9 support for real

### DIFF
--- a/leveldb/storage/file_storage_plan9.go
+++ b/leveldb/storage/file_storage_plan9.go
@@ -29,7 +29,12 @@ func newFileLock(path string) (fl fileLock, err error) {
 }
 
 func rename(oldpath, newpath string) error {
-	os.Remove(newpath)
+	if _, err := os.Stat(newpath); err == nil {
+		if err := os.Remove(newpath); err != nil {
+			return err
+		}
+	}
+
 	_, fname := filepath.Split(newpath)
 	return os.Rename(oldpath, fname)
 }


### PR DESCRIPTION
remove os.O_EXCL, it's not what we want. that just prevents os.O_CREATE from creating if the file exists.
what we want is os.ModeExclusive, which on plan 9, is DMEXCL, aka the lock bit, which should be equivalent to posix flock(fd, LOCK_EX).

furthermore, fix rename. on plan 9, you can't pass a full path to Wstat, which is what os.Rename does under the hood. just pass the last path component.
we have to os.Remove first, because Wstat fails if the target exists.
hopefully rename() is not used to move files between different dirs, because then this won't work.

re-fix #30.
