### PR TITLE
On Windows, you cannot rename a currently opened file.

### DIFF
--- a/leveldb/storage/file_storage.go
+++ b/leveldb/storage/file_storage.go
@@ -303,17 +303,23 @@ func (fs *fileStorage) SetManifest(f File) (err error) {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := w.Close(); err != nil {
-			fs.log(fmt.Sprintf("close CURRENT.%d: %v", f2.num, err))
-		}
-	}()
 	_, err = fmt.Fprintln(w, f2.name())
 	if err != nil {
+		if cerr := w.Close(); cerr != nil {
+			fs.log(fmt.Sprintf("close CURRENT.%d: %v", f2.num, cerr))
+		}
 		return err
 	}
-	err = rename(path, filepath.Join(fs.path, "CURRENT"))
-	return
+	err = w.Close()
+	if err != nil {
+		fs.log(fmt.Sprintf("close CURRENT.%d: %v", f2.num, err))
+
+		// Return if we cannot Close(), since rename will fail on Windows
+		// if the file is still open.
+		return err
+	}
+
+	return rename(path, filepath.Join(fs.path, "CURRENT"))
 }
 
 func (fs *fileStorage) Close() error {


### PR DESCRIPTION
Remove the defer Close() and explicitly call it again.

PASS
ok      github.com/syndtr/goleveldb/leveldb     51.647s

Fixes Issue #33
