### PR TITLE
Added perens to d.file.Num.

### DIFF
--- a/leveldb/session_util.go
+++ b/leveldb/session_util.go
@@ -25,7 +25,7 @@ func (d dropper) Drop(err error) {
 	if e, ok := err.(journal.DroppedError); ok {
 		d.s.logf("journal@drop %s-%d S·%s %q", d.file.Type(), d.file.Num(), shortenb(e.Size), e.Reason)
 	} else {
-		d.s.logf("journal@drop %s-%d %q", d.file.Type(), d.file.Num, err)
+		d.s.logf("journal@drop %s-%d %q", d.file.Type(), d.file.Num(), err)
 	}
 }
 


### PR DESCRIPTION
I was getting a compilation error when trying to build this:
`./session_util.go:28: method d.file.Num is not an expression, must be called`
Adding the perens to d.file.Num() corrected it for me. Issue #43
