### PR TITLE
Bug fix: allow querying the "leveldb.num-files-at-level<n>" property

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -661,7 +661,7 @@ func (db *DB) GetSnapshot() (*Snapshot, error) {
 //
 // Property names:
 //	leveldb.num-files-at-level{n}
-//		Returns the number of filer at level 'n'.
+//		Returns the number of files at level 'n'.
 //	leveldb.stats
 //		Returns statistics of the underlying DB.
 //	leveldb.sstables
@@ -691,11 +691,12 @@ func (db *DB) GetProperty(name string) (value string, err error) {
 	v := db.s.version()
 	defer v.release()
 
+	numFilesPrefix := "num-files-at-level"
 	switch {
-	case strings.HasPrefix(p, "num-files-at-level"):
+	case strings.HasPrefix(p, numFilesPrefix):
 		var level uint
 		var rest string
-		n, _ := fmt.Scanf("%d%s", &level, &rest)
+		n, _ := fmt.Sscanf(p[len(numFilesPrefix):], "%d%s", &level, &rest)
 		if n != 1 || level >= kNumLevels {
 			err = errors.New("leveldb: GetProperty: invalid property: " + name)
 		} else {

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -2022,3 +2022,23 @@ func TestDb_GoleveldbIssue74(t *testing.T) {
 	}()
 	wg.Wait()
 }
+
+func TestDb_GetProperties(t *testing.T) {
+	h := newDbHarness(t)
+	defer h.close()
+
+	_, err := h.db.GetProperty("leveldb.num-files-at-level")
+	if err == nil {
+		t.Error("GetProperty() failed to detect missing level")
+	}
+
+	_, err = h.db.GetProperty("leveldb.num-files-at-level0")
+	if err != nil {
+		t.Error("got unexpected error", err)
+	}
+
+	_, err = h.db.GetProperty("leveldb.num-files-at-level0x")
+	if err == nil {
+		t.Error("GetProperty() failed to detect invalid level")
+	}
+}


### PR DESCRIPTION
The DB.GetProperty() erroneously used fmt.Scanf() instead of
fmt.Sscanf() when trying to parse the level in properties of the form
"leveldb.num-files-at-level<n>".  This commit changes the method
to use fmt.Sscanf() instead, and adds a test case to check for the
presence of the problem.
