### PR TITLE
Update Snappy imports to use new canonical path

### DIFF
--- a/leveldb/table/reader.go
+++ b/leveldb/table/reader.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/go-snappy/snappy"
+	"github.com/golang/snappy/snappy"
 
 	"github.com/syndtr/goleveldb/leveldb/cache"
 	"github.com/syndtr/goleveldb/leveldb/comparer"

--- a/leveldb/table/writer.go
+++ b/leveldb/table/writer.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/google/go-snappy/snappy"
+	"github.com/golang/snappy/snappy"
 
 	"github.com/syndtr/goleveldb/leveldb/comparer"
 	"github.com/syndtr/goleveldb/leveldb/filter"


### PR DESCRIPTION
The Snappy path has recently changed: https://github.com/golang/snappy/issues/12

This PR updates the imports in `reader.go` and `writer.go` respectively.