### PR TITLE
Ack existing writes before accepting new ones

### DIFF
--- a/leveldb/db_write.go
+++ b/leveldb/db_write.go
@@ -166,14 +166,14 @@ func (db *DB) Write(b *Batch, wo *opt.WriteOptions) (err error) {
 	merged := 0
 	danglingMerge := false
 	defer func() {
+		for i := 0; i < merged; i++ {
+			db.writeAckC <- err
+		}
 		if danglingMerge {
 			// Only one dangling merge at most, so this is safe.
 			db.writeMergedC <- false
 		} else {
 			<-db.writeLockC
-		}
-		for i := 0; i < merged; i++ {
-			db.writeAckC <- err
 		}
 	}()
 


### PR DESCRIPTION
This PR fixes a logical race reported in https://github.com/syndtr/goleveldb/issues/136.

The database writes in the current code are optimized, so that if multiple ones are pending, they are aggregated into a mega batch, written out as a single operation and then all of the individual writes acked at once.

The race is in the termination part of the write, where the writer goroutine first released the write lock, and only then acked the merged writes. This leaves a small gap open for a new write to begin, and that new write itself to accumulate merges of its own. The issue is then that the initial writer will acknowledge merges other than its own, leading to unfinished writes being signaled as done.

The fix is to move the acks before releasing the write lock, essentially exhausting all of the goroutines waiting for write acks before allowing further ones to get into that position.

Running the tests results in:

```
/work/src/github.com/syndtr/goleveldb/leveldb$ go test
Running Suite: LevelDB Suite
============================
Random Seed: 1457622809
Will run 58 of 58 specs

•••••••••••••••••••••••••••••••••••••••••••••••••••••••
------------------------------
• [SLOW TEST:7.278 seconds]
Leveldb external
/work/src/github.com/syndtr/goleveldb/leveldb/external_test.go:116
  read test
  /work/src/github.com/syndtr/goleveldb/leveldb/external_test.go:56
    with generated key/value
    /work/src/github.com/syndtr/goleveldb/leveldb/testutil/kvtest.go:210
      Should iterates and seeks slice correctly
      /work/src/github.com/syndtr/goleveldb/leveldb/testutil/kvtest.go:165
------------------------------
•
------------------------------
• [SLOW TEST:7.070 seconds]
Leveldb external
/work/src/github.com/syndtr/goleveldb/leveldb/external_test.go:116
  transaction test
  /work/src/github.com/syndtr/goleveldb/leveldb/external_test.go:115
    should do transaction correctly
    /work/src/github.com/syndtr/goleveldb/leveldb/external_test.go:114
------------------------------

Ran 58 of 58 Specs in 18.922 seconds
SUCCESS! -- 58 Passed | 0 Failed | 0 Pending | 0 Skipped PASS
ok  	github.com/syndtr/goleveldb/leveldb	98.620s

```