### PR TITLE
storage: fix compilation with GOOS=nacl

### DIFF
--- a/leveldb/storage/file_storage_nacl.go
+++ b/leveldb/storage/file_storage_nacl.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2012, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// +build nacl
+
+package storage
+
+import (
+	"os"
+	"syscall"
+)
+
+func newFileLock(path string, readOnly bool) (fl fileLock, err error) {
+	return nil, syscall.ENOTSUP
+}
+
+func setFileLock(f *os.File, readOnly, lock bool) error {
+	return syscall.ENOTSUP
+}
+
+func rename(oldpath, newpath string) error {
+	return syscall.ENOTSUP
+}
+
+func isErrInvalid(err error) bool {
+	return false
+}
+
+func syncDir(name string) error {
+	return syscall.ENOTSUP
+}


### PR DESCRIPTION
This change makes leveldb compile and work in Native Client.
All file system functions return syscall.ENOTSUP because nacl has
no file system.