### PR TITLE
leveldb: add BufferPool accessor

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -1089,3 +1089,9 @@ func (db *DB) Close() error {
 
 	return err
 }
+
+// BufferPool returns the buffer pool used by database operations.
+// It can be used to put buffers returned by Get back into the pool.
+func (db *DB) BufferPool() *util.BufferPool {
+	return db.s.tops.bpool
+}


### PR DESCRIPTION
The buffer pool is a major source of wasted allocations in our program.
All reads we do look like this (using JSON as an example)

```go
buf, _ := db.Get(key, nil)
var value SomeType
json.Unmarshal(buf, &value)
```

With this commit the buffer can be returned to the pool after decoding.

```go
db.BufferPool().Put(buf)
```
