### PR TITLE
Fixed rename on plan 9 (invalid argument error).

### DIFF
--- a/leveldb/storage/file_storage_plan9.go
+++ b/leveldb/storage/file_storage_plan9.go
@@ -8,7 +8,6 @@ package storage
 
 import (
 	"os"
-	"path/filepath"
 )
 
 type plan9FileLock struct {
@@ -48,8 +47,7 @@ func rename(oldpath, newpath string) error {
 		}
 	}
 
-	_, fname := filepath.Split(newpath)
-	return os.Rename(oldpath, fname)
+	return os.Rename(oldpath, newpath)
 }
 
 func syncDir(name string) error {


### PR DESCRIPTION
The workaround for rename introduced with
45d424a47028cb8fd1bea3f4814d489a6a6db525 is no longer needed/valid.
Since commit 16dcef80d46d78cc198bfc680e9cf05cea9095cc (December 2013)
in golang/go repository os.Rename was changed to accept (and expect) a
full path for new path (albeit the file should be in the same
directory).