### PR TITLE
leveldb: add effective disk read and write statistics

### DIFF
--- a/leveldb/storage/iostats.go
+++ b/leveldb/storage/iostats.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2018, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package storage
+
+import (
+	"sync/atomic"
+)
+
+// IOStats holds the cumulative number of read and written bytes of the underlying storage.
+type IOStats struct {
+	read  uint64
+	write uint64
+}
+
+// AddRead increases the number of read bytes by n.
+func (s *IOStats) AddRead(n uint64) uint64 {
+	return atomic.AddUint64(&s.read, n)
+}
+
+// AddWrite increases the number of written bytes by n.
+func (s *IOStats) AddWrite(n uint64) uint64 {
+	return atomic.AddUint64(&s.write, n)
+}
+
+// Reads returns the number of read bytes.
+func (s *IOStats) Reads() uint64 {
+	return atomic.LoadUint64(&s.read)
+}
+
+// Writes returns the number of written bytes.
+func (s *IOStats) Writes() uint64 {
+	return atomic.LoadUint64(&s.write)
+}

--- a/leveldb/storage/storage.go
+++ b/leveldb/storage/storage.go
@@ -177,3 +177,8 @@ type Storage interface {
 	// called after the storage has been closed.
 	Close() error
 }
+
+// MeteredStorage collects read and write statistics.
+type MeteredStorage interface {
+	Stats() *IOStats
+}

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -356,8 +356,12 @@ func (t *tOps) open(f *tFile) (ch *cache.Handle, err error) {
 			bcache = &cache.NamespaceGetter{Cache: t.bcache, NS: uint64(f.fd.Num)}
 		}
 
+		var ioStats *storage.IOStats
+		if fs, ok := t.s.stor.(storage.MeteredStorage); ok {
+			ioStats = fs.Stats()
+		}
 		var tr *table.Reader
-		tr, err = table.NewReader(r, f.size, f.fd, bcache, t.bpool, t.s.o.Options)
+		tr, err = table.NewReader(r, f.size, f.fd, bcache, t.bpool, ioStats, t.s.o.Options)
 		if err != nil {
 			r.Close()
 			return 0, nil

--- a/leveldb/table/table_test.go
+++ b/leveldb/table/table_test.go
@@ -60,7 +60,7 @@ var _ = testutil.Defer(func() {
 			It("Should be able to approximate offset of a key correctly", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
-				tr, err := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()), storage.FileDesc{}, nil, nil, o)
+				tr, err := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()), storage.FileDesc{}, nil, nil, nil, o)
 				Expect(err).ShouldNot(HaveOccurred())
 				CheckOffset := func(key string, expect, threshold int) {
 					offset, err := tr.OffsetOf([]byte(key))
@@ -97,7 +97,7 @@ var _ = testutil.Defer(func() {
 				tw.Close()
 
 				// Opening the table.
-				tr, _ := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()), storage.FileDesc{}, nil, nil, o)
+				tr, _ := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()), storage.FileDesc{}, nil, nil, nil, o)
 				return tableWrapper{tr}
 			}
 			Test := func(kv *testutil.KeyValue, body func(r *Reader)) func() {


### PR DESCRIPTION
Hello,

We need to measure the amount of data read from and written to the file storage in order to optimize the database usage. Here is a previous related issue: https://github.com/syndtr/goleveldb/issues/113

`IOStats` contains the cumulative number of read and written bytes, and every read and write operations should update its state.

Does this approach cover all the disk read and write?