### PR TITLE
leveldb/storage: correct FileType masking and Rename in MemStorage

### DIFF
--- a/leveldb/storage/mem_storage.go
+++ b/leveldb/storage/mem_storage.go
@@ -12,7 +12,11 @@ import (
 	"sync"
 )
 
-const typeShift = 3
+const typeShift = 4
+
+// Verify at compile-time that typeShift is large enough to cover all FileType
+// values by confirming that 0 == 0.
+var _ [0]struct{} = [TypeAll >> typeShift]struct{}{}
 
 type memStorageLock struct {
 	ms *memStorage
@@ -143,7 +147,7 @@ func (ms *memStorage) Remove(fd FileDesc) error {
 }
 
 func (ms *memStorage) Rename(oldfd, newfd FileDesc) error {
-	if FileDescOk(oldfd) || FileDescOk(newfd) {
+	if !FileDescOk(oldfd) || !FileDescOk(newfd) {
 		return ErrInvalidFile
 	}
 	if oldfd == newfd {

--- a/leveldb/storage/mem_storage_test.go
+++ b/leveldb/storage/mem_storage_test.go
@@ -8,6 +8,7 @@ package storage
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -61,5 +62,56 @@ func TestMemStorage(t *testing.T) {
 	}
 	if _, err := m.Open(FileDesc{TypeTable, 1}); err == nil {
 		t.Fatal("expecting error")
+	}
+}
+
+func TestMemStorageRename(t *testing.T) {
+	fd1 := FileDesc{Type: TypeTable, Num: 1}
+	fd2 := FileDesc{Type: TypeTable, Num: 2}
+
+	m := NewMemStorage()
+	w, err := m.Create(fd1)
+	if err != nil {
+		t.Fatalf("Storage.Create: %v", err)
+	}
+
+	fmt.Fprintf(w, "abc")
+	w.Close()
+
+	rd, err := m.Open(fd1)
+	if err != nil {
+		t.Fatalf("Storage.Open(%v): %v", fd1, err)
+	}
+	rd.Close()
+
+	fds, err := m.List(TypeAll)
+	if err != nil {
+		t.Fatalf("Storage.List: %v", err)
+	}
+	for _, fd := range fds {
+		if !FileDescOk(fd) {
+			t.Errorf("Storage.List -> FileDescOk(%q)", fd)
+		}
+	}
+
+	err = m.Rename(fd1, fd2)
+	if err != nil {
+		t.Fatalf("Storage.Rename: %v", err)
+	}
+
+	rd, err = m.Open(fd2)
+	if err != nil {
+		t.Fatalf("Storage.Open(%v): %v", fd2, err)
+	}
+	rd.Close()
+
+	fds, err = m.List(TypeAll)
+	if err != nil {
+		t.Fatalf("Storage.List: %v", err)
+	}
+	for _, fd := range fds {
+		if !FileDescOk(fd) {
+			t.Errorf("Storage.List -> FileDescOk(%q)", fd)
+		}
 	}
 }


### PR DESCRIPTION
The `typeShift` constant used in `storage.NewMemStorage` doesn't cover all of the states, so the `List` method returns invalid `FileDesc` values.

Further, the `Rename` method for in-memory storage doesn't work since it requires both the new and old filename to be _invalid_, rather than requiring them both to be valid.

This change tests for and fixes both bugs.