### PR TITLE
Update log file size in fileStore.doLog method

### DIFF
--- a/leveldb/storage/file_storage.go
+++ b/leveldb/storage/file_storage.go
@@ -189,7 +189,8 @@ func (fs *fileStorage) doLog(t time.Time, str string) {
 	// write
 	fs.buf = append(fs.buf, []byte(str)...)
 	fs.buf = append(fs.buf, '\n')
-	fs.logw.Write(fs.buf)
+	n, _ := fs.logw.Write(fs.buf)
+	fs.logSize += int64(n)
 }
 
 func (fs *fileStorage) Log(str string) {


### PR DESCRIPTION
increase fs.logSize when writing in LOG file.

issue: https://github.com/syndtr/goleveldb/issues/216