### PR TITLE
leveldb: add write paused flag

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -1002,6 +1002,7 @@ func (db *DB) GetProperty(name string) (value string, err error) {
 type DBStats struct {
 	WriteDelayCount    int32
 	WriteDelayDuration time.Duration
+	WritePaused        bool
 
 	AliveSnapshots int32
 	AliveIterators int32
@@ -1030,6 +1031,7 @@ func (db *DB) Stats(s *DBStats) error {
 	s.IOWrite = db.s.stor.writes()
 	s.WriteDelayCount = atomic.LoadInt32(&db.cWriteDelayN)
 	s.WriteDelayDuration = time.Duration(atomic.LoadInt64(&db.cWriteDelay))
+	s.WritePaused = atomic.LoadInt32(&db.inWritePaused) == 1
 
 	s.OpenedTablesCount = db.s.tops.cache.Size()
 	if db.s.tops.bcache != nil {

--- a/leveldb/db_write.go
+++ b/leveldb/db_write.go
@@ -89,7 +89,11 @@ func (db *DB) flush(n int) (mdb *memDB, mdbFree int, err error) {
 			return false
 		case tLen >= pauseTrigger:
 			delayed = true
+			// Set the write paused flag explicitly.
+			atomic.StoreInt32(&db.inWritePaused, 1)
 			err = db.compTriggerWait(db.tcompCmdC)
+			// Unset the write paused flag.
+			atomic.StoreInt32(&db.inWritePaused, 0)
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
In this PR, introduces a new flag `WritePaused`.
Currently we expose `WriteDelayN` and `WriteDelay` statistic to outer, so that external user can  know that the system is performing compaction and all write operations will be paused.

**But these two statistics will be added only after the long compaction finished**, so that external user doesn't know what happened to leveldb during this long procedure.

The `WritePaused` flag can notify external user that the long compaction has begun and all writes will be suspended for a period of time
