### PR TITLE
leveldb/storage: catch EINVAL on go >= 1.8 too

### DIFF
--- a/leveldb/storage/file_storage_unix.go
+++ b/leveldb/storage/file_storage_unix.go
@@ -67,7 +67,12 @@ func isErrInvalid(err error) bool {
 	if err == os.ErrInvalid {
 		return true
 	}
+	// Go < 1.8
 	if syserr, ok := err.(*os.SyscallError); ok && syserr.Err == syscall.EINVAL {
+		return true
+	}
+	// Go >= 1.8 returns *os.PathError instead
+	if patherr, ok := err.(*os.PathError); ok && patherr.Err == syscall.EINVAL {
 		return true
 	}
 	return false


### PR DESCRIPTION
In go 1.8, various functions were updated to return PathError instead.
This includes `os.File Sync()`.

For reference, the upstream commit which made this change is
https://github.com/golang/go/commit/212d2f82e05.

Arguably we could take this as a signal that upstream doesn't consider
this error type stable, so rather than attempt to identify it we could
assume any error from Sync should be ignored, but I think there's some
amount of value still in trying to error out on things like ENOSPACE or
EBADF.

This should re-fix #103 and fix the perkeep issue https://github.com/perkeep/perkeep/issues/1185