### PR TITLE
leveldb: expose compaction statistic when leveldb is write paused

### DIFF
--- a/leveldb/db_write.go
+++ b/leveldb/db_write.go
@@ -94,6 +94,7 @@ func (db *DB) flush(n int) (mdb *memDB, mdbFree int, err error) {
 			err = db.compTriggerWait(db.tcompCmdC)
 			// Unset the write paused flag.
 			atomic.StoreInt32(&db.inWritePaused, 0)
+			db.wpCompStat.clean()
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
Currently we have accumulated compaction statistic, but these data only be updated after the compaction finished. If there is a long compaction, although we can tell user that `hey we are under a very long compaction, keep waiting`, but user will never know when this compaction can be finished.

In this PR, i expose some statistic data for in-flight compaction: 
1. The total data needed to be processed in this compaction;
2. The compaction has generated how much data(It sounds weird, we should put the data compaction has processed here, but unfortunately it is difficulty to fetch accurate processed data, so we can use the generated data as a reference)
3. The compaction has elapsed how much time.

So in theory, the user can have a basic idea how long the compaction **may** last although the number is not very accurate.