### PR TITLE
Update docs for iterator Prev / Next to be unambiguous.

### DIFF
--- a/leveldb/iterator/iter.go
+++ b/leveldb/iterator/iter.go
@@ -40,11 +40,11 @@ type IteratorSeeker interface {
 	Seek(key []byte) bool
 
 	// Next moves the iterator to the next key/value pair.
-	// It returns whether the iterator is exhausted.
+	// It returns false if the iterator is exhausted.
 	Next() bool
 
 	// Prev moves the iterator to the previous key/value pair.
-	// It returns whether the iterator is exhausted.
+	// It returns false if the iterator is exhausted.
 	Prev() bool
 }
 


### PR DESCRIPTION
Just a small rewording to make the docstring for the iterator's `Prev()` and `Next()` methods clearer.

The current formulation...
> It returns whether the iterator is exhausted.

...suggests that eg. `Next()` would return `true` when the iterator is exhausted.