### PR TITLE
Run go vet in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ go:
   - tip
 
 script:
+  - go vet ./...
   - go test -timeout 1h ./...
   - go test -timeout 30m -race -run "TestDB_(Concurrent|GoleveldbIssue74)" ./leveldb

--- a/leveldb/cache/cache.go
+++ b/leveldb/cache/cache.go
@@ -331,7 +331,6 @@ func (r *Cache) delete(n *Node) bool {
 			return deleted
 		}
 	}
-	return false
 }
 
 // Nodes returns number of 'cache node' in the map.

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -431,7 +431,7 @@ func (h *dbHarness) compactRange(min, max string) {
 
 func (h *dbHarness) sizeOf(start, limit string) int64 {
 	sz, err := h.db.SizeOf([]util.Range{
-		{[]byte(start), []byte(limit)},
+		{Start: []byte(start), Limit: []byte(limit)},
 	})
 	if err != nil {
 		h.t.Error("SizeOf: got error: ", err)
@@ -1592,7 +1592,7 @@ func TestDB_ClosedIsClosed(t *testing.T) {
 	_, err = db.GetProperty("leveldb.stats")
 	assertErr(t, err, true)
 
-	_, err = db.SizeOf([]util.Range{{[]byte("a"), []byte("z")}})
+	_, err = db.SizeOf([]util.Range{{Start: []byte("a"), Limit: []byte("z")}})
 	assertErr(t, err, true)
 
 	assertErr(t, db.CompactRange(util.Range{}), true)

--- a/leveldb/db_util.go
+++ b/leveldb/db_util.go
@@ -84,7 +84,7 @@ func (db *DB) checkAndCleanFiles() error {
 		var mfds []storage.FileDesc
 		for num, present := range tmap {
 			if !present {
-				mfds = append(mfds, storage.FileDesc{storage.TypeTable, num})
+				mfds = append(mfds, storage.FileDesc{Type: storage.TypeTable, Num: num})
 				db.logf("db@janitor table missing @%d", num)
 			}
 		}

--- a/leveldb/session_util.go
+++ b/leveldb/session_util.go
@@ -36,7 +36,7 @@ func (s *session) logf(format string, v ...interface{}) { s.stor.Log(fmt.Sprintf
 
 func (s *session) newTemp() storage.FileDesc {
 	num := atomic.AddInt64(&s.stTempFileNum, 1) - 1
-	return storage.FileDesc{storage.TypeTemp, num}
+	return storage.FileDesc{Type: storage.TypeTemp, Num: num}
 }
 
 func (s *session) addFileRef(fd storage.FileDesc, ref int) int {
@@ -190,7 +190,7 @@ func (s *session) recordCommited(rec *sessionRecord) {
 
 // Create a new manifest file; need external synchronization.
 func (s *session) newManifest(rec *sessionRecord, v *version) (err error) {
-	fd := storage.FileDesc{storage.TypeManifest, s.allocFileNum()}
+	fd := storage.FileDesc{Type: storage.TypeManifest, Num: s.allocFileNum()}
 	writer, err := s.stor.Create(fd)
 	if err != nil {
 		return

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -78,7 +78,7 @@ func newTableFile(fd storage.FileDesc, size int64, imin, imax internalKey) *tFil
 }
 
 func tableFileFromRecord(r atRecord) *tFile {
-	return newTableFile(storage.FileDesc{storage.TypeTable, r.num}, r.size, r.imin, r.imax)
+	return newTableFile(storage.FileDesc{Type: storage.TypeTable, Num: r.num}, r.size, r.imin, r.imax)
 }
 
 // tFiles hold multiple tFile.
@@ -299,7 +299,7 @@ type tOps struct {
 
 // Creates an empty table and returns table writer.
 func (t *tOps) create() (*tWriter, error) {
-	fd := storage.FileDesc{storage.TypeTable, t.s.allocFileNum()}
+	fd := storage.FileDesc{Type: storage.TypeTable, Num: t.s.allocFileNum()}
 	fw, err := t.s.stor.Create(fd)
 	if err != nil {
 		return nil, err

--- a/leveldb/testutil/storage.go
+++ b/leveldb/testutil/storage.go
@@ -147,7 +147,10 @@ func packFile(fd storage.FileDesc) uint64 {
 }
 
 func unpackFile(x uint64) storage.FileDesc {
-	return storage.FileDesc{storage.FileType(x) & storage.TypeAll, int64(x >> typeCount)}
+	return storage.FileDesc{
+		Type: storage.FileType(x) & storage.TypeAll,
+		Num:  int64(x >> typeCount),
+	}
 }
 
 type emulatedError struct {

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -526,7 +526,7 @@ func main() {
 								getStat.record(1)
 
 								if checksum0, checksum1 := dataChecksum(v2); checksum0 != checksum1 {
-									err := &errors.ErrCorrupted{Fd: storage.FileDesc{0xff, 0}, Err: fmt.Errorf("v2: %x: checksum mismatch: %v vs %v", v2, checksum0, checksum1)}
+									err := &errors.ErrCorrupted{Fd: storage.FileDesc{Type: 0xff, Num: 0}, Err: fmt.Errorf("v2: %x: checksum mismatch: %v vs %v", v2, checksum0, checksum1)}
 									fatalf(err, "[%02d] READER #%d.%d K%d snap.Get: %v\nk1: %x\n -> k2: %x", ns, snapwi, ri, n, err, k1, k2)
 								}
 


### PR DESCRIPTION
Cleans up a few `go vet` related errors:

```
$ go vet ./...
leveldb/cache/cache.go:334: unreachable code
manualtest/dbstress/main.go:529: github.com/syndtr/goleveldb/leveldb/storage.FileDesc composite literal uses unkeyed fields
leveldb/testutil/storage.go:150: github.com/syndtr/goleveldb/leveldb/storage.FileDesc composite literal uses unkeyed fields
leveldb/db_util.go:87: github.com/syndtr/goleveldb/leveldb/storage.FileDesc composite literal uses unkeyed fields
leveldb/session_util.go:39: github.com/syndtr/goleveldb/leveldb/storage.FileDesc composite literal uses unkeyed fields
leveldb/session_util.go:193: github.com/syndtr/goleveldb/leveldb/storage.FileDesc composite literal uses unkeyed fields
leveldb/table.go:81: github.com/syndtr/goleveldb/leveldb/storage.FileDesc composite literal uses unkeyed fields
leveldb/table.go:302: github.com/syndtr/goleveldb/leveldb/storage.FileDesc composite literal uses unkeyed fields
leveldb/db_test.go:434: github.com/syndtr/goleveldb/leveldb/util.Range composite literal uses unkeyed fields
leveldb/db_test.go:1595: github.com/syndtr/goleveldb/leveldb/util.Range composite literal uses unkeyed fields
```