### PR TITLE
Use Sizes in Stats

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -1017,10 +1017,10 @@ type DBStats struct {
 	BlockCacheSize    int
 	OpenedTablesCount int
 
-	LevelSizes        []int64
+	LevelSizes        Sizes
 	LevelTablesCounts []int
-	LevelRead         []int64
-	LevelWrite        []int64
+	LevelRead         Sizes
+	LevelWrite        Sizes
 	LevelDurations    []time.Duration
 }
 


### PR DESCRIPTION
Use the `Sizes` object in `Stats` so the caller can call `Sizes.Sum()`. This would break existing callers so maybe better left as is, but thought it might be nice to wrap with a type. What do you think?