### PR TITLE
leveldb: skip resort for delete only level

### DIFF
--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -486,6 +486,12 @@ func (p *versionStaging) finish(trivial bool) *version {
 				nt = append(nt, t)
 			}
 
+			// Avoid resort if only files in this level are deleted
+			if len(scratch.added) == 0 {
+				nv.levels[level] = nt
+				continue
+			}
+
 			// For normal table compaction, one compaction will only involve two levels
 			// of files. And the new files generated after merging the source level and
 			// source+1 level related files can be inserted as a whole into source+1 level


### PR DESCRIPTION
This PR includes a small fix for compaction commit.

For the delete-only level, we can just remove specified files from the base level and then use it as the new version. No qsort needed.