### PR TITLE
leveldb: optimize getOverlap by binary search

### DIFF
--- a/leveldb/session_compaction.go
+++ b/leveldb/session_compaction.go
@@ -181,10 +181,14 @@ func (c *compaction) expand() {
 
 	t0, t1 := c.levels[0], c.levels[1]
 	imin, imax := t0.getRange(c.s.icmp)
-	// We expand t0 here just incase ukey hop across tables.
-	t0 = vt0.getOverlaps(t0, c.s.icmp, imin.ukey(), imax.ukey(), c.sourceLevel == 0)
-	if len(t0) != len(c.levels[0]) {
-		imin, imax = t0.getRange(c.s.icmp)
+
+	// For non-zero levels, the ukey can't hop across tables at all.
+	if c.sourceLevel == 0 {
+		// We expand t0 here just incase ukey hop across tables.
+		t0 = vt0.getOverlaps(t0, c.s.icmp, imin.ukey(), imax.ukey(), c.sourceLevel == 0)
+		if len(t0) != len(c.levels[0]) {
+			imin, imax = t0.getRange(c.s.icmp)
+		}
 	}
 	t1 = vt1.getOverlaps(t1, c.s.icmp, imin.ukey(), imax.ukey(), false)
 	// Get entire range covered by compaction.

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -7,6 +7,7 @@
 package leveldb
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"sync/atomic"
@@ -158,6 +159,22 @@ func (tf tFiles) searchNumLess(num int64) int {
 	})
 }
 
+// Searches smallest index of tables whose its smallest
+// key is after the given key.
+func (tf tFiles) searchMinUkey(icmp *iComparer, umin []byte) int {
+	return sort.Search(len(tf), func(i int) bool {
+		return icmp.ucmp.Compare(tf[i].imin.ukey(), umin) > 0
+	})
+}
+
+// Searches smallest index of tables whose its largest
+// key is after the given key.
+func (tf tFiles) searchMaxUkey(icmp *iComparer, umax []byte) int {
+	return sort.Search(len(tf), func(i int) bool {
+		return icmp.ucmp.Compare(tf[i].imax.ukey(), umax) > 0
+	})
+}
+
 // Returns true if given key range overlaps with one or more
 // tables key range. If unsorted is true then binary search will not be used.
 func (tf tFiles) overlaps(icmp *iComparer, umin, umax []byte, unsorted bool) bool {
@@ -189,6 +206,50 @@ func (tf tFiles) overlaps(icmp *iComparer, umin, umax []byte, unsorted bool) boo
 // expanded.
 // The dst content will be overwritten.
 func (tf tFiles) getOverlaps(dst tFiles, icmp *iComparer, umin, umax []byte, overlapped bool) tFiles {
+	// Short circuit if tf is empty
+	if len(tf) == 0 {
+		return nil
+	}
+	// For non-zero levels, there is no ukey hop across at all.
+	// And what's more, the files in these levels are strictly sorted,
+	// so use binary search instead of heavy traverse.
+	if !overlapped {
+		var begin, end int
+		// Determine the begin index of the overlapped file
+		if umin != nil {
+			index := tf.searchMinUkey(icmp, umin)
+			if index == 0 {
+				begin = 0
+			} else if bytes.Compare(tf[index-1].imax.ukey(), umin) >= 0 {
+				// The min ukey overlaps with the index-1 file, expand it.
+				begin = index - 1
+			} else {
+				begin = index
+			}
+		}
+		// Determine the end index of the overlapped file
+		if umax != nil {
+			index := tf.searchMaxUkey(icmp, umax)
+			if index == len(tf) {
+				end = len(tf)
+			} else if bytes.Compare(tf[index].imin.ukey(), umax) <= 0 {
+				// The max ukey overlaps with the index file, expand it.
+				end = index + 1
+			} else {
+				end = index
+			}
+		} else {
+			end = len(tf)
+		}
+		// Ensure the overlapped file indexes are valid.
+		if begin >= end {
+			return nil
+		}
+		dst = make([]*tFile, end-begin)
+		copy(dst, tf[begin:end])
+		return dst
+	}
+
 	dst = dst[:0]
 	for i := 0; i < len(tf); {
 		t := tf[i]
@@ -201,11 +262,9 @@ func (tf tFiles) getOverlaps(dst tFiles, icmp *iComparer, umin, umax []byte, ove
 			} else if umax != nil && icmp.uCompare(t.imax.ukey(), umax) > 0 {
 				umax = t.imax.ukey()
 				// Restart search if it is overlapped.
-				if overlapped {
-					dst = dst[:0]
-					i = 0
-					continue
-				}
+				dst = dst[:0]
+				i = 0
+				continue
 			}
 
 			dst = append(dst, t)

--- a/leveldb/table_test.go
+++ b/leveldb/table_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2019, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package leveldb
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/syndtr/goleveldb/leveldb/testutil"
+)
+
+func TestGetOverlaps(t *testing.T) {
+	gomega.RegisterTestingT(t)
+	stor := testutil.NewStorage()
+	defer stor.Close()
+	s, err := newSession(stor, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v := newVersion(s)
+	v.newStaging()
+
+	tmp := make([]byte, 4)
+	mik := func(i uint64, typ keyType, ukey bool) []byte {
+		if i == 0 {
+			return nil
+		}
+		binary.BigEndian.PutUint32(tmp, uint32(i))
+		if ukey {
+			key := make([]byte, 4)
+			copy(key, tmp)
+			return key
+		}
+		return []byte(makeInternalKey(nil, tmp, 0, typ))
+	}
+
+	rec := &sessionRecord{}
+	for i, f := range []struct {
+		min   uint64
+		max   uint64
+		level int
+	}{
+		// Overlapped level 0 files
+		{1, 8, 0},
+		{4, 5, 0},
+		{6, 10, 0},
+		// Non-overlapped level 1 files
+		{2, 3, 1},
+		{8, 10, 1},
+		{13, 13, 1},
+		{20, 100, 1},
+	} {
+		rec.addTable(f.level, int64(i), 1, mik(f.min, keyTypeVal, false), mik(f.max, keyTypeVal, false))
+	}
+	vs := v.newStaging()
+	vs.commit(rec)
+	v = vs.finish(false)
+
+	for i, x := range []struct {
+		min      uint64
+		max      uint64
+		level    int
+		expected []int64
+	}{
+		// Level0 cases
+		{0, 0, 0, []int64{2, 1, 0}},
+		{1, 0, 0, []int64{2, 1, 0}},
+		{0, 10, 0, []int64{2, 1, 0}},
+		{2, 7, 0, []int64{2, 1, 0}},
+
+		// Level1 cases
+		{1, 1, 1, nil},
+		{0, 100, 1, []int64{3, 4, 5, 6}},
+		{5, 0, 1, []int64{4, 5, 6}},
+		{5, 4, 1, nil}, // invalid search space
+		{1, 13, 1, []int64{3, 4, 5}},
+		{2, 13, 1, []int64{3, 4, 5}},
+		{3, 13, 1, []int64{3, 4, 5}},
+		{4, 13, 1, []int64{4, 5}},
+		{4, 19, 1, []int64{4, 5}},
+		{4, 20, 1, []int64{4, 5, 6}},
+		{4, 100, 1, []int64{4, 5, 6}},
+		{4, 105, 1, []int64{4, 5, 6}},
+	} {
+		tf := v.levels[x.level]
+		res := tf.getOverlaps(nil, s.icmp, mik(x.min, keyTypeSeek, true), mik(x.max, keyTypeSeek, true), x.level == 0)
+
+		var fnums []int64
+		for _, f := range res {
+			fnums = append(fnums, f.fd.Num)
+		}
+		if !reflect.DeepEqual(x.expected, fnums) {
+			t.Errorf("case %d failed, expected %v, got %v", i, x.expected, fnums)
+		}
+	}
+}
+
+func BenchmarkGetOverlapLevel0(b *testing.B) {
+	benchmarkGetOverlap(b, 0, 500000)
+}
+
+func BenchmarkGetOverlapNonLevel0(b *testing.B) {
+	benchmarkGetOverlap(b, 1, 500000)
+}
+
+func benchmarkGetOverlap(b *testing.B, level int, size int) {
+	stor := storage.NewMemStorage()
+	defer stor.Close()
+	s, err := newSession(stor, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	v := newVersion(s)
+	v.newStaging()
+
+	tmp := make([]byte, 4)
+	mik := func(i uint64, typ keyType, ukey bool) []byte {
+		if i == 0 {
+			return nil
+		}
+		binary.BigEndian.PutUint32(tmp, uint32(i))
+		if ukey {
+			key := make([]byte, 4)
+			copy(key, tmp)
+			return key
+		}
+		return []byte(makeInternalKey(nil, tmp, 0, typ))
+	}
+
+	rec := &sessionRecord{}
+	for i := 1; i <= size; i++ {
+		min := mik(uint64(2*i), keyTypeVal, false)
+		max := mik(uint64(2*i+1), keyTypeVal, false)
+		rec.addTable(level, int64(i), 1, min, max)
+	}
+	vs := v.newStaging()
+	vs.commit(rec)
+	v = vs.finish(false)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		files := v.levels[level]
+		start := rand.Intn(size)
+		end := rand.Intn(size-start) + start
+		files.getOverlaps(nil, s.icmp, mik(uint64(2*start), keyTypeVal, true), mik(uint64(2*end), keyTypeVal, true), level == 0)
+	}
+}


### PR DESCRIPTION
This PR introduce an optimization for `getOverlaps` function.

In the original implementation, it will traverse all files to find the overlapped file. It is the only approach for level0 since the files are overlapped. While for non-zero files, we can use binary search as the replacement.
