### PR TITLE
leveldb: introduce seed file expansion idea

### DIFF
--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -22,25 +22,27 @@ const (
 )
 
 var (
-	DefaultBlockCacher                   = LRUCacher
-	DefaultBlockCacheCapacity            = 8 * MiB
-	DefaultBlockRestartInterval          = 16
-	DefaultBlockSize                     = 4 * KiB
-	DefaultCompactionExpandLimitFactor   = 25
-	DefaultCompactionGPOverlapsFactor    = 10
-	DefaultCompactionL0Trigger           = 4
-	DefaultCompactionSourceLimitFactor   = 1
-	DefaultCompactionTableSize           = 2 * MiB
-	DefaultCompactionTableSizeMultiplier = 1.0
-	DefaultCompactionTotalSize           = 10 * MiB
-	DefaultCompactionTotalSizeMultiplier = 10.0
-	DefaultCompressionType               = SnappyCompression
-	DefaultIteratorSamplingRate          = 1 * MiB
-	DefaultOpenFilesCacher               = LRUCacher
-	DefaultOpenFilesCacheCapacity        = 500
-	DefaultWriteBuffer                   = 4 * MiB
-	DefaultWriteL0PauseTrigger           = 12
-	DefaultWriteL0SlowdownTrigger        = 8
+	DefaultBlockCacher                        = LRUCacher
+	DefaultBlockCacheCapacity                 = 8 * MiB
+	DefaultBlockRestartInterval               = 16
+	DefaultBlockSize                          = 4 * KiB
+	DefaultCompactionExpandLimitFactor        = 25
+	DefaultCompactionGPOverlapsFactor         = 10
+	DefaultCompactionL0Trigger                = 4
+	DefaultCompactionSourceLimitFactor        = 1
+	DefaultCompactionTableSize                = 2 * MiB
+	DefaultCompactionTableSizeMultiplier      = 1.0
+	DefaultCompactionTotalSize                = 10 * MiB
+	DefaultCompactionTotalSizeMultiplier      = 10.0
+	DefaultCompactionSeedFileNumber           = 1
+	DefaultCompactionSeedFileNumberMultiplier = 2
+	DefaultCompressionType                    = SnappyCompression
+	DefaultIteratorSamplingRate               = 1 * MiB
+	DefaultOpenFilesCacher                    = LRUCacher
+	DefaultOpenFilesCacheCapacity             = 500
+	DefaultWriteBuffer                        = 4 * MiB
+	DefaultWriteL0PauseTrigger                = 12
+	DefaultWriteL0SlowdownTrigger             = 8
 )
 
 // Cacher is a caching algorithm.
@@ -235,6 +237,22 @@ type Options struct {
 	//
 	// The default value is 10.
 	CompactionTotalSizeMultiplier float64
+
+	// CompactionSeedFileNumber defines the seed file number of a compaction.
+	// This doesn't apply to level-0.
+	// The seed file number for each level will be calculated as:
+	//   SeedFileNumber = CompactionSeedFileNumber * (CompactionSeedFileNumberMultiplier ^ (CompactionScore-1))
+	//
+	// The default value is 1.
+	CompactionSeedFileNumber int
+
+	// CompactionSeedFileNumberMultiplier defines the multiplier for CompactionSeedFileNumber.
+	// This doesn't apply to level-0.
+	// The seed file number for each level will be calculated as:
+	//   SeedFileNumber = CompactionSeedFileNumber * (CompactionSeedFileNumberMultiplier ^ (CompactionScore-1))
+	//
+	// The default value is 2.
+	CompactionSeedFileNumberMultiplier int
 
 	// CompactionTotalSizeMultiplierPerLevel defines per-level multiplier for
 	// CompactionTotalSize.
@@ -482,6 +500,26 @@ func (o *Options) GetCompactionTotalSize(level int) int64 {
 		mult = math.Pow(DefaultCompactionTotalSizeMultiplier, float64(level))
 	}
 	return int64(float64(base) * mult)
+}
+
+func (o *Options) GetCompactionSeedFileNumber(score float64) int {
+	// Short circuit for invalid score
+	if score < 1 {
+		return 0
+	}
+	var (
+		base = DefaultCompactionSeedFileNumber
+		mult = DefaultCompactionSeedFileNumberMultiplier
+	)
+	if o != nil {
+		if o.CompactionSeedFileNumber > 0 {
+			base = o.CompactionSeedFileNumber
+		}
+		if o.CompactionSeedFileNumberMultiplier > 0 {
+			mult = o.CompactionSeedFileNumberMultiplier
+		}
+	}
+	return base * int(math.Pow(float64(mult), score-1))
 }
 
 func (o *Options) GetComparer() comparer.Comparer {


### PR DESCRIPTION
This PR introduces an optimization for reducing compaction overhead.

For compaction, expect the old files read and new files write, there also a lot of overhead which including:

* new version finish
* version reference & release
* pick compaction

From my test result, the overhead occupies a lot of CPU time. So the straightforward idea is "try to merge several single compactions into a big one to let them share the overhead".

This PR proposes to expand the seed files instead of 1. Leveldb picks a level to compact by the score. In the worst case, the write operation is paused if the level0 files number is larger than 12(the score of level0 is 3). So it means the score normally shouldn't beyond 3. 

And regarding the non-zero level, if the score is pretty high(e.g. 3), it means there are a lot of files need to be compacted. So we can easily merge than by expanding the seed file number to `math.Pow(2, (score-1))`.

What's more I add two configuration options for the expanding formula:
* `CompactionSeedFileNumber `
* `CompactionSeedFileNumberMultiplier `
The formula is now `CompactionSeedFileNumber * math.Pow(CompactionSeedFileNumberMultiplier, (score - 1))`