### PR TITLE
leveldb: make heavy version reference asynchronous

### DIFF
--- a/leveldb/corrupt_test.go
+++ b/leveldb/corrupt_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
@@ -481,6 +482,7 @@ func TestCorruptDB_RecoverTable(t *testing.T) {
 	h.compactRangeAt(0, "", "")
 	h.compactRangeAt(1, "", "")
 	seq := h.db.seq
+	time.Sleep(100 * time.Millisecond) // Wait lazy reference finish tasks
 	h.closeDB()
 	h.corrupt(storage.TypeTable, 0, 1000, 1)
 	h.corrupt(storage.TypeTable, 3, 10000, 1)

--- a/leveldb/session.go
+++ b/leveldb/session.go
@@ -53,9 +53,18 @@ type session struct {
 	manifestWriter storage.Writer
 	manifestFd     storage.FileDesc
 
-	stCompPtrs []internalKey // compaction pointers; need external synchronization
-	stVersion  *version      // current version
-	vmu        sync.Mutex
+	stCompPtrs  []internalKey // compaction pointers; need external synchronization
+	stVersion   *version      // current version
+	ntVersionId int64         // next version id to assign
+	refCh       chan *vTask
+	relCh       chan *vTask
+	deltaCh     chan *vDelta
+	closeC      chan struct{}
+	closeW      sync.WaitGroup
+	vmu         sync.Mutex
+
+	// Testing fields
+	fileRefCh chan chan map[int64]int // channel used to pass current reference stat
 }
 
 // Creates new initialized session instance.
@@ -68,13 +77,21 @@ func newSession(stor storage.Storage, o *opt.Options) (s *session, err error) {
 		return
 	}
 	s = &session{
-		stor:     newIStorage(stor),
-		storLock: storLock,
-		fileRef:  make(map[int64]int),
+		stor:      newIStorage(stor),
+		storLock:  storLock,
+		fileRef:   make(map[int64]int),
+		refCh:     make(chan *vTask),
+		relCh:     make(chan *vTask),
+		deltaCh:   make(chan *vDelta),
+		fileRefCh: make(chan chan map[int64]int),
+		closeC:    make(chan struct{}),
 	}
 	s.setOptions(o)
 	s.tops = newTableOps(s)
-	s.setVersion(newVersion(s))
+
+	s.closeW.Add(1)
+	go s.refLoop()
+	s.setVersion(nil, newVersion(s))
 	s.log("log@legend F·NumFile S·FileSize N·Entry C·BadEntry B·BadBlock Ke·KeyError D·DroppedEntry L·Level Q·SeqNum T·TimeElapsed")
 	return
 }
@@ -90,7 +107,11 @@ func (s *session) close() {
 	}
 	s.manifest = nil
 	s.manifestWriter = nil
-	s.setVersion(&version{s: s, closing: true})
+	s.setVersion(nil, &version{s: s, closing: true, id: s.ntVersionId})
+
+	// Close all background goroutines
+	close(s.closeC)
+	s.closeW.Wait()
 }
 
 // Release session lock.
@@ -180,7 +201,7 @@ func (s *session) recover() (err error) {
 	}
 
 	s.manifestFd = fd
-	s.setVersion(staging.finish(false))
+	s.setVersion(rec, staging.finish(false))
 	s.setNextFileNum(rec.nextFileNum)
 	s.recordCommited(rec)
 	return nil
@@ -203,7 +224,7 @@ func (s *session) commit(r *sessionRecord, trivial bool) (err error) {
 
 	// finally, apply new version if no error rise
 	if err == nil {
-		s.setVersion(nv)
+		s.setVersion(r, nv)
 	}
 
 	return

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -424,15 +424,15 @@ func (t *tOps) newIterator(f *tFile, slice *util.Range, ro *opt.ReadOptions) ite
 
 // Removes table from persistent storage. It waits until
 // no one use the the table.
-func (t *tOps) remove(f *tFile) {
-	t.cache.Delete(0, uint64(f.fd.Num), func() {
-		if err := t.s.stor.Remove(f.fd); err != nil {
-			t.s.logf("table@remove removing @%d %q", f.fd.Num, err)
+func (t *tOps) remove(fd storage.FileDesc) {
+	t.cache.Delete(0, uint64(fd.Num), func() {
+		if err := t.s.stor.Remove(fd); err != nil {
+			t.s.logf("table@remove removing @%d %q", fd.Num, err)
 		} else {
-			t.s.logf("table@remove removed @%d", f.fd.Num)
+			t.s.logf("table@remove removed @%d", fd.Num)
 		}
 		if t.evictRemoved && t.bcache != nil {
-			t.bcache.EvictNS(uint64(f.fd.Num))
+			t.bcache.EvictNS(uint64(fd.Num))
 		}
 	})
 }

--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -40,9 +40,10 @@ type version struct {
 	released bool
 }
 
+// newVersion creates a new version with an unique monotonous increasing id.
 func newVersion(s *session) *version {
-	nv := &version{s: s, id: s.ntVersionId}
-	s.ntVersionId += 1
+	id := atomic.AddInt64(&s.ntVersionId, 1)
+	nv := &version{s: s, id: id - 1}
 	return nv
 }
 

--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -22,7 +22,8 @@ type tSet struct {
 }
 
 type version struct {
-	s *session
+	id int64 // unique monotonous increasing version id
+	s  *session
 
 	levels []tFiles
 
@@ -40,7 +41,9 @@ type version struct {
 }
 
 func newVersion(s *session) *version {
-	return &version{s: s}
+	nv := &version{s: s, id: s.ntVersionId}
+	s.ntVersionId += 1
+	return nv
 }
 
 func (v *version) incref() {
@@ -50,11 +53,11 @@ func (v *version) incref() {
 
 	v.ref++
 	if v.ref == 1 {
-		// Incr file ref.
-		for _, tt := range v.levels {
-			for _, t := range tt {
-				v.s.addFileRef(t.fd, 1)
-			}
+		select {
+		case v.s.refCh <- &vTask{vid: v.id, files: v.levels}:
+			// We can use v.levels directly here since it is immutable.
+		case <-v.s.closeC:
+			v.s.log("reference loop already exist")
 		}
 	}
 }
@@ -66,13 +69,11 @@ func (v *version) releaseNB() {
 	} else if v.ref < 0 {
 		panic("negative version ref")
 	}
-
-	for _, tt := range v.levels {
-		for _, t := range tt {
-			if v.s.addFileRef(t.fd, -1) == 0 {
-				v.s.tops.remove(t)
-			}
-		}
+	select {
+	case v.s.relCh <- &vTask{vid: v.id, files: v.levels}:
+		// We can use v.levels directly here since it is immutable.
+	case <-v.s.closeC:
+		v.s.log("reference loop already exist")
 	}
 
 	v.released = true


### PR DESCRIPTION
This PR introduces an efficient approach for table file reference.

The original for file reference is:
* When the database version is first time created, then references all relative table files by increasing file ref by 1
* When the version is released(no operation hold the version), deferences all  table files by decreasing file ref by 1

If the database size is 1TB with each file size is 2MB, image the cost for 500,000 file reference cost.
And worse, the read operation(also iterator) will also acquire a version before reading. And it has **very high possibility** then this read operation is the last thing holding the version, it means the cost of huge file deferences is distributed to the read operation. **It will definitely slow down the entire system**.

Therefore I introduce an efficient approach for it. Notably, the new version is ONLY created by compaction. While luckily we have the `changed file set` for every compaction(no matter mem_compaction or table_compaction). All we need to is "delay reference opt and wait for release opt, use the `changed file set` to delete useless files and reference new generated files".

Two things we need to care about:
* We have to process version reference and deference one by one, otherwise we can delete some files that are referencing now.
* Some operation like iterator can hold a version for a very long time. It means such operation can block the entire processing queue. In order to break it, we need to convert some version task to normal mode(references all files and also deferences)