### PR TITLE
Add minimal support for WebAssembly

### DIFF
--- a/leveldb/storage/file_storage_js.go
+++ b/leveldb/storage/file_storage_js.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2012, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// +build js,wasm
+
+package storage
+
+import (
+	"os"
+	"sync"
+	"syscall"
+)
+
+// Note: JavaScript doesn't have an flock syscall so we have to fake it. This
+// won't work if another process tries to read/write to the same file. It only
+// works in the context of this process, but is safe with multiple goroutines.
+
+// locksMu protects access to readLocks and writeLocks
+var locksMu = sync.Mutex{}
+
+// readLocks is a map of path to the number of readers.
+var readLocks = map[string]uint{}
+
+// writeLocks keeps track
+var writeLocks = map[string]struct{}{}
+
+type jsFileLock struct {
+	path     string
+	readOnly bool
+	file     *os.File
+}
+
+func (fl *jsFileLock) release() error {
+	if fl.readOnly {
+		locksMu.Lock()
+		defer locksMu.Unlock()
+		count, found := readLocks[fl.path]
+		if found {
+			if count == 1 {
+				// If this is the last reader, delete the entry from the map.
+				delete(readLocks, fl.path)
+			} else {
+				// Otherwise decrement the number of readers.
+				readLocks[fl.path] = count - 1
+			}
+		}
+	} else {
+		delete(writeLocks, fl.path)
+	}
+	return fl.file.Close()
+}
+
+func newFileLock(path string, readOnly bool) (fl fileLock, err error) {
+	var flag int
+	if readOnly {
+		flag = os.O_RDONLY
+	} else {
+		flag = os.O_RDWR
+	}
+	var file *os.File
+	if file, err = os.OpenFile(path, flag, 0); err != nil && os.IsNotExist(err) {
+		file, err = os.OpenFile(path, flag|os.O_CREATE, 0644)
+	}
+	if err != nil {
+		return
+	}
+	if err := setFileLock(path, readOnly); err != nil {
+		return nil, err
+	}
+	return &jsFileLock{file: file, path: path}, nil
+}
+
+func setFileLock(path string, readOnly bool) error {
+	locksMu.Lock()
+	defer locksMu.Unlock()
+
+	// If the file is already write locked, neither writers or readers are
+	// allowed.
+	_, hasWriter := writeLocks[path]
+	if hasWriter {
+		return syscall.EAGAIN
+	}
+
+	readCount, hasReader := readLocks[path]
+	if readOnly {
+		// Multiple concurrent readers are allowed. Increment the read counter.
+		if hasReader {
+			readLocks[path] = readCount + 1
+		} else {
+			readLocks[path] = 1
+		}
+	} else {
+		// Writers are not allowed if the file is read locked.
+		if hasReader {
+			return syscall.EAGAIN
+		}
+		writeLocks[path] = struct{}{}
+	}
+
+	return nil
+}
+
+func rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
+func isErrInvalid(err error) bool {
+	if err == os.ErrInvalid {
+		return true
+	}
+	// Go < 1.8
+	if syserr, ok := err.(*os.SyscallError); ok && syserr.Err == syscall.EINVAL {
+		return true
+	}
+	// Go >= 1.8 returns *os.PathError instead
+	if patherr, ok := err.(*os.PathError); ok && patherr.Err == syscall.EINVAL {
+		return true
+	}
+	return false
+}
+
+func syncDir(name string) error {
+	// As per fsync manpage, Linux seems to expect fsync on directory, however
+	// some system don't support this, so we will ignore syscall.EINVAL.
+	//
+	// From fsync(2):
+	//   Calling fsync() does not necessarily ensure that the entry in the
+	//   directory containing the file has also reached disk. For that an
+	//   explicit fsync() on a file descriptor for the directory is also needed.
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := f.Sync(); err != nil && !isErrInvalid(err) {
+		return err
+	}
+	return nil
+}

--- a/leveldb/storage/file_storage_test.go
+++ b/leveldb/storage/file_storage_test.go
@@ -392,7 +392,7 @@ func TestFileStorage_ReadOnlyLocking(t *testing.T) {
 	if err != nil {
 		t.Logf("OpenFile(5): got error: %s (expected)", err)
 	} else {
-		t.Fatal("OpenFile(2): expect error")
+		t.Fatal("OpenFile(5): expect error")
 	}
 
 	p3.Close()


### PR DESCRIPTION
This PR adds minimal support for compiling LevelDB to WebAssembly. WebAssembly support was added to the Go compiler starting with version 1.11 and you can read the [Official Wiki Page](https://github.com/golang/go/wiki/WebAssembly) for more information about how it works.

Most of the codebase already works in WebAssembly without any changes 😄One thing that doesn't work out of the box is the `leveldb/storage` package. The Go compiler already makes use of the `fs` package in Node.js when compiling to WebAssembly. It is easy to open, read, and write to files in a Node.js environment using the Go standard library. The only thing I needed to add in this PR was support for file locks, since the existing implementations (e.g., __file_storage_unix.go__) rely on OS-specific syscalls.

The implementation of file locks that I wrote here is not perfect. Unfortunately Node.js does not support true file locks, so my implementation relies on in-memory maps protected by a mutex. This means it does not prevent other processes from accessing the files. However, I believe it is good enough for most use cases.

You can compile Go tests to WebAssembly and run them in a Node.js environment by running `GOOS=js GOARCH=wasm go test ./...`. Currently, large parts of the test suite fail to build because Ginkgo does not support WebAssembly. It is possible that there are test cases that would fail too if the build were to succeed. However, if you limit the tests to only the `leveldb/storage` package, they pass! You can try it yourself with `GOOS=js GOARCH=wasm go test ./leveldb/storage -v`.

Additionally, with the changes in this PR, I was able to compile this simple program to WebAssembly and run it with `GOOS=js GOARCH=wasm go run main.go`:

```go
package main

import (
	"fmt"

	"github.com/syndtr/goleveldb/leveldb"
)

func main() {
	db, err := leveldb.OpenFile("leveldb_test", nil)
	defer db.Close()
	if err != nil {
		panic(err)
	}

	fmt.Println("Setting value foo = bar")
	if err := db.Put([]byte("foo"), []byte("bar"), nil); err != nil {
		panic(err)
	}
	value, err := db.Get([]byte("foo"), nil)
	if err != nil {
		panic(err)
	}
	fmt.Printf("Got value: %q\n", value)
}
```

Working in Node.js is one thing, but browser support is arguably more interesting. I have done some initial testing and it looks like it is possible to get LevelDB working in the browser by using [BrowserFS](https://github.com/jvilk/BrowserFS) to emulate the Node.js `fs` package. One problem with that right now is that the Go compiler/runtime expects the `fs` package to support the special file descriptors 0, 1, and 2 for stdin, stdout, and stderr respectively. I [opened this issue](https://github.com/jvilk/BrowserFS/issues/271) to add support for these special file descriptors to BrowserFS.

In any case, if you are interested, I can work more on supporting LevelDB in the browser in the future. There are a number of strategies we could use here and not all of them depend on making changes to BrowserFS.