### PR TITLE
db.go: Don't skip some level for Stat

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -1070,9 +1070,7 @@ func (db *DB) Stats(s *DBStats) error {
 
 	for level, tables := range v.levels {
 		duration, read, write := db.compStats.getStat(level)
-		if len(tables) == 0 && duration == 0 {
-			continue
-		}
+
 		s.LevelDurations = append(s.LevelDurations, duration)
 		s.LevelRead = append(s.LevelRead, read)
 		s.LevelWrite = append(s.LevelWrite, write)


### PR DESCRIPTION
we get LevelTablesCounts = [65,34], seems L0 file num is 65
after reopen db,  LevelTablesCounts = [1,65,34]
the origin LevelTablesCounts should be [0,65,34]
if it skip some level, we have no any ideal what the Stat we get really
means