### PR TITLE
opt: introduce DontTriggerCompaction into ReadOptions

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -778,7 +778,7 @@ func (db *DB) get(auxm *memdb.DB, auxt tFiles, key []byte, seq uint64, ro *opt.R
 	v := db.s.version()
 	value, cSched, err := v.get(auxt, ikey, ro, false)
 	v.release()
-	if cSched {
+	if cSched && !ro.GetDontTriggerCompaction() {
 		// Trigger table compaction.
 		db.compTrigger(db.tcompCmdC)
 	}
@@ -816,7 +816,7 @@ func (db *DB) has(auxm *memdb.DB, auxt tFiles, key []byte, seq uint64, ro *opt.R
 	v := db.s.version()
 	_, cSched, err := v.get(auxt, ikey, ro, true)
 	v.release()
-	if cSched {
+	if cSched && !ro.GetDontTriggerCompaction() {
 		// Trigger table compaction.
 		db.compTrigger(db.tcompCmdC)
 	}

--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -635,6 +635,12 @@ type ReadOptions struct {
 	// Strict will be OR'ed with global DB 'strict level' unless StrictOverride
 	// is present. Currently only StrictReader that has effect here.
 	Strict Strict
+
+	// DontTriggerCompaction defines whether this 'read operation' allowed to trigger
+	// compaction. If false then compaction is allowed to be triggered.
+	//
+	// The default value is false.
+	DontTriggerCompaction bool
 }
 
 func (ro *ReadOptions) GetDontFillCache() bool {
@@ -649,6 +655,13 @@ func (ro *ReadOptions) GetStrict(strict Strict) bool {
 		return false
 	}
 	return ro.Strict&strict != 0
+}
+
+func (ro *ReadOptions) GetDontTriggerCompaction() bool {
+	if ro == nil {
+		return false
+	}
+	return ro.DontTriggerCompaction
 }
 
 // WriteOptions holds the optional parameters for 'write operation'. The


### PR DESCRIPTION
In some case, compaction triggered by read operations is not expected. Because the compaction won't improve read performance, but waste disk writes. e.g. LevelDB storing Ethereum MPT.

The new read option `DontTriggerCompaction` is for such special case.