### PR TITLE
pre allocate memory for batch data

### DIFF
--- a/leveldb/batch.go
+++ b/leveldb/batch.go
@@ -72,6 +72,14 @@ type Batch struct {
 	internalLen int
 }
 
+func NewBatch(n int) *Batch {
+	batch:= &Batch{}
+	if n > 0 {
+		batch.data = make([]byte, 0, n)
+	}
+	return batch
+}
+
 func (b *Batch) grow(n int) {
 	o := len(b.data)
 	if cap(b.data)-o < n {


### PR DESCRIPTION
For batch operation, if there is a lot of keys to put in one batch, it would be time consuming to grow data size again and again. so if we can pre allocate memory for data, it would avoid this issue.