### PR TITLE
leveldb, manualtest: introduce dontcompaction read opt

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -38,6 +38,12 @@ type DB struct {
 	inWritePaused          int32 // The indicator whether write operation is paused by compaction
 	aliveSnaps, aliveIters int32
 
+	// Compaction statistic
+	minorComp     uint32 // The cumulative number of memory compaction
+	level0Comp    uint32 // The cumulative number of level0 compaction
+	nonLevel0Comp uint32 // The cumulative number of non-level0 compaction
+	seekComp      uint32 // The cumulative number of seek compaction
+
 	// Session.
 	s *session
 
@@ -978,6 +984,8 @@ func (db *DB) GetProperty(name string) (value string, err error) {
 		value += fmt.Sprintf(" Total | %10d | %13.5f | %13.5f | %13.5f | %13.5f\n",
 			totalTables, float64(totalSize)/1048576.0, totalDuration.Seconds(),
 			float64(totalRead)/1048576.0, float64(totalWrite)/1048576.0)
+	case p == "compcount":
+		value = fmt.Sprintf("MinorComp:%d Level0Comp:%d NonLevel0Comp:%d SeekComp:%d", atomic.LoadUint32(&db.minorComp), atomic.LoadUint32(&db.level0Comp), atomic.LoadUint32(&db.nonLevel0Comp), atomic.LoadUint32(&db.seekComp))
 	case p == "iostats":
 		value = fmt.Sprintf("Read(MB):%.5f Write(MB):%.5f",
 			float64(db.s.stor.reads())/1048576.0,
@@ -1034,6 +1042,11 @@ type DBStats struct {
 	LevelRead         Sizes
 	LevelWrite        Sizes
 	LevelDurations    []time.Duration
+
+	MinorComp     uint32
+	Level0Comp    uint32
+	NonLevel0Comp uint32
+	SeekComp      uint32
 }
 
 // Stats populates s with database statistics.
@@ -1078,6 +1091,10 @@ func (db *DB) Stats(s *DBStats) error {
 		s.LevelTablesCounts = append(s.LevelTablesCounts, len(tables))
 	}
 
+	s.MinorComp = atomic.LoadUint32(&db.minorComp)
+	s.Level0Comp = atomic.LoadUint32(&db.level0Comp)
+	s.NonLevel0Comp = atomic.LoadUint32(&db.nonLevel0Comp)
+	s.SeekComp = atomic.LoadUint32(&db.seekComp)
 	return nil
 }
 

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -8,6 +8,7 @@ package leveldb
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/syndtr/goleveldb/leveldb/errors"
@@ -324,10 +325,12 @@ func (db *DB) memCompaction() {
 
 	db.logf("memdb@flush committed F·%d T·%v", len(rec.addedTables), stats.duration)
 
+	// Save compaction stats
 	for _, r := range rec.addedTables {
 		stats.write += r.size
 	}
 	db.compStats.addStat(flushLevel, stats)
+	atomic.AddUint32(&db.minorComp, 1)
 
 	// Drop frozen memdb.
 	db.dropFrozenMem()
@@ -587,6 +590,14 @@ func (db *DB) tableCompaction(c *compaction, noTrivial bool) {
 	// Save compaction stats
 	for i := range stats {
 		db.compStats.addStat(c.sourceLevel+1, &stats[i])
+	}
+	switch c.typ {
+	case level0Compaction:
+		atomic.AddUint32(&db.level0Comp, 1)
+	case nonLevel0Compaction:
+		atomic.AddUint32(&db.nonLevel0Comp, 1)
+	case seekCompaction:
+		atomic.AddUint32(&db.seekComp, 1)
 	}
 }
 

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -2565,7 +2565,7 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 
 	// Build grandparent.
 	v := s.version()
-	c := newCompaction(s, v, 1, append(tFiles{}, v.levels[1]...))
+	c := newCompaction(s, v, 1, append(tFiles{}, v.levels[1]...), undefinedCompaction)
 	rec := &sessionRecord{}
 	b := &tableCompactionBuilder{
 		s:         s,
@@ -2589,7 +2589,7 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 
 	// Build level-1.
 	v = s.version()
-	c = newCompaction(s, v, 0, append(tFiles{}, v.levels[0]...))
+	c = newCompaction(s, v, 0, append(tFiles{}, v.levels[0]...), undefinedCompaction)
 	rec = &sessionRecord{}
 	b = &tableCompactionBuilder{
 		s:         s,
@@ -2633,7 +2633,7 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 
 	// Compaction with transient error.
 	v = s.version()
-	c = newCompaction(s, v, 1, append(tFiles{}, v.levels[1]...))
+	c = newCompaction(s, v, 1, append(tFiles{}, v.levels[1]...), undefinedCompaction)
 	rec = &sessionRecord{}
 	b = &tableCompactionBuilder{
 		s:         s,

--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -635,6 +635,12 @@ type ReadOptions struct {
 	// Strict will be OR'ed with global DB 'strict level' unless StrictOverride
 	// is present. Currently only StrictReader that has effect here.
 	Strict Strict
+
+	// DontTriggerCompaction defines whether this 'read operation' allowed to trigger
+	// compaction. If false then compaction is allowed to be triggered.
+	//
+	// The default value is false.
+	DontTriggerCompaction bool
 }
 
 func (ro *ReadOptions) GetDontFillCache() bool {
@@ -649,6 +655,13 @@ func (ro *ReadOptions) GetStrict(strict Strict) bool {
 		return false
 	}
 	return ro.Strict&strict != 0
+}
+
+func (ro *ReadOptions) GetDontTriggerCompaction() bool {
+	if ro == nil {
+		return false
+	}
+	return ro.DontTriggerCompaction
 }
 
 // WriteOptions holds the optional parameters for 'write operation'. The

--- a/leveldb/session_compaction.go
+++ b/leveldb/session_compaction.go
@@ -14,6 +14,13 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
+const (
+	undefinedCompaction = iota
+	level0Compaction
+	nonLevel0Compaction
+	seekCompaction
+)
+
 func (s *session) pickMemdbLevel(umin, umax []byte, maxLevel int) int {
 	v := s.version()
 	defer v.release()
@@ -50,6 +57,7 @@ func (s *session) pickCompaction() *compaction {
 
 	var sourceLevel int
 	var t0 tFiles
+	var typ int
 	if v.cScore >= 1 {
 		sourceLevel = v.cLevel
 		cptr := s.getCompPtr(sourceLevel)
@@ -63,18 +71,24 @@ func (s *session) pickCompaction() *compaction {
 		if len(t0) == 0 {
 			t0 = append(t0, tables[0])
 		}
+		if sourceLevel == 0 {
+			typ = level0Compaction
+		} else {
+			typ = nonLevel0Compaction
+		}
 	} else {
 		if p := atomic.LoadPointer(&v.cSeek); p != nil {
 			ts := (*tSet)(p)
 			sourceLevel = ts.level
 			t0 = append(t0, ts.table)
+			typ = seekCompaction
 		} else {
 			v.release()
 			return nil
 		}
 	}
 
-	return newCompaction(s, v, sourceLevel, t0)
+	return newCompaction(s, v, sourceLevel, t0, typ)
 }
 
 // Create compaction from given level and range; need external synchronization.
@@ -108,14 +122,18 @@ func (s *session) getCompactionRange(sourceLevel int, umin, umax []byte, noLimit
 			}
 		}
 	}
-
-	return newCompaction(s, v, sourceLevel, t0)
+	typ := level0Compaction
+	if sourceLevel != 0 {
+		typ = nonLevel0Compaction
+	}
+	return newCompaction(s, v, sourceLevel, t0, typ)
 }
 
-func newCompaction(s *session, v *version, sourceLevel int, t0 tFiles) *compaction {
+func newCompaction(s *session, v *version, sourceLevel int, t0 tFiles, typ int) *compaction {
 	c := &compaction{
 		s:             s,
 		v:             v,
+		typ:           typ,
 		sourceLevel:   sourceLevel,
 		levels:        [2]tFiles{t0, nil},
 		maxGPOverlaps: int64(s.o.GetCompactionGPOverlaps(sourceLevel)),
@@ -131,6 +149,7 @@ type compaction struct {
 	s *session
 	v *version
 
+	typ           int
 	sourceLevel   int
 	levels        [2]tFiles
 	maxGPOverlaps int64

--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -232,7 +232,7 @@ func (v *version) get(aux tFiles, ikey internalKey, ro *opt.ReadOptions, noValue
 		return true
 	})
 
-	if tseek && tset.table.consumeSeek() <= 0 {
+	if !ro.GetDontTriggerCompaction() && tseek && tset.table.consumeSeek() <= 0 {
 		tcomp = atomic.CompareAndSwapPointer(&v.cSeek, nil, unsafe.Pointer(tset))
 	}
 

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -165,7 +165,7 @@ func (ts *testingStorage) scanTable(fd storage.FileDesc, checksum bool) (corrupt
 
 	o := &opt.Options{
 		DisableLargeBatchTransaction: true,
-		Strict: opt.NoStrict,
+		Strict:                       opt.NoStrict,
 	}
 	if checksum {
 		o.Strict = opt.StrictBlockChecksum | opt.StrictReader
@@ -427,8 +427,9 @@ func main() {
 			blockpool, _ := db.GetProperty("leveldb.blockpool")
 			writeDelay, _ := db.GetProperty("leveldb.writedelay")
 			ioStats, _ := db.GetProperty("leveldb.iostats")
-			log.Printf("> BlockCache=%s OpenedTables=%s AliveSnaps=%s AliveIter=%s BlockPool=%q WriteDelay=%q IOStats=%q",
-				cachedblock, openedtables, alivesnaps, aliveiters, blockpool, writeDelay, ioStats)
+			compCount, _ := db.GetProperty("leveldb.compcount")
+			log.Printf("> BlockCache=%s OpenedTables=%s AliveSnaps=%s AliveIter=%s BlockPool=%q WriteDelay=%q IOStats=%q CompCount=%q",
+				cachedblock, openedtables, alivesnaps, aliveiters, blockpool, writeDelay, ioStats, compCount)
 			log.Print("------------------------")
 		}
 	}()


### PR DESCRIPTION
Continue the work from #285

This PR introduces a new read-option `DontTriggerCompaction`, so that caller can control whether the seek compaction will be triggered.

**TL;DR**: we can reduce seek compaction number at some use-case if read pressure is much heavier than write.

***

Seek compaction is: Each file has a counter which is size/16KB. When the counter goes down to 0, then the file is compacted.

The rationale behinds this is: the cost of file compaction is approximate with cumulative seek cost.

Regarding the deep reason of seek compaction, my understand is:
(1) If we try to lookup one entry in level X, and there exists a file has the overlapped key range, so we will try to look up the entry in this file. However, if we can't find it but in the deeper level, we meet another file which also has the overlapped key range, then the counter of the file is increased.

So it means we always try to compact a file at low level which has key range overlap with a deeper level file.

(2) The main goal of seek compaction is distributing the compaction pressure:
If we only have major compaction and minor compaction, then the shape of leveldb is fixed: we first fill the level0, then level1, ... 
The issue here is if the first X levels are full, then whenever we generate a new file at level0, we need to immediately compact some file to level1 and compact some file to level2. Data needs to flow from the lower level to the deeper layer immediately. Otherwise, the lower level will have no space to store new data.

***
So with seek compaction, we can compact some files even there is no new file generated. So that the shape of leveldb is dynamic. For example, the level2 is full but level1 may not full. Essentially we distribute some compactions during the read time so that the system is more stable. 

But if for some system, the read pressure is much higher than write(even worse, like ethererum: the db key of all entries are random hash, so entries are distributed to entire DB randomly). In this case, **too many seek compaction will increase the burden of system extremely**.

***

A few metric charts:

![image](https://user-images.githubusercontent.com/5959481/65104913-bd789a00-da05-11e9-9ee1-e03ba6f04d54.png)

![image](https://user-images.githubusercontent.com/5959481/65104897-b05bab00-da05-11e9-8438-8790740f02dc.png)

![image](https://user-images.githubusercontent.com/5959481/65104929-c79a9880-da05-11e9-8c67-2bf5a612ae17.png)

When the read pressure is very high, the system runs compaction non-stop. IOwait is going to the roof.

Besides, we ran some benchmarks which reduce 2/3 seek compaction, it shows the disk IO reduced a lot. Performance-wise, there is no big difference. Check [PR](https://github.com/ethereum/go-ethereum/pull/20030) for more details.