### PR TITLE
Merge a lot of optimize from bytes.Buffer

### DIFF
--- a/leveldb/util/buffer_test.go
+++ b/leveldb/util/buffer_test.go
@@ -339,6 +339,30 @@ func TestBufferGrowth(t *testing.T) {
 	}
 }
 
+func BenchmarkWriteByte(b *testing.B) {
+	const n = 4 << 10
+	b.SetBytes(n)
+	buf := NewBuffer(make([]byte, n))
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		for i := 0; i < n; i++ {
+			buf.WriteByte('x')
+		}
+	}
+}
+
+func BenchmarkAlloc(b *testing.B) {
+	const n = 4 << 10
+	b.SetBytes(n)
+	buf := NewBuffer(make([]byte, n))
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		for i := 0; i < n; i++ {
+			buf.Alloc(1)
+		}
+	}
+}
+
 // BenchmarkBufferNotEmptyWriteRead: From Issue 5154.
 func BenchmarkBufferNotEmptyWriteRead(b *testing.B) {
 	buf := make([]byte, 1024)


### PR DESCRIPTION
Hi @syndtr ,

I merge a lot of optimize from bytes.Buffer, e.g.:

https://github.com/golang/go/commit/55310403ddf051634fa398b4c9e6013d530753f5
https://github.com/golang/go/commit/c08ac36761d3dc03d0a0b0ffb240c4a7c524536b
https://github.com/golang/go/commit/1ba4556a2c84f552f7c9697ad7323fd6cdbc6970


```
name                       old time/op   new time/op   delta
WriteByte-4                 22.9µs ± 2%   14.8µs ± 1%  -35.54%  (p=0.008 n=5+5)
Alloc-4                     22.5µs ± 1%   18.8µs ± 0%  -16.23%  (p=0.004 n=5+6)
BufferNotEmptyWriteRead-4    276µs ± 2%    301µs ± 3%   +8.97%  (p=0.004 n=5+6)
BufferFullSmallReads-4      73.2µs ±24%   63.3µs ± 3%  -13.49%  (p=0.002 n=6+6)

name                       old speed     new speed     delta
WriteByte-4                179MB/s ± 2%  277MB/s ± 1%  +55.12%  (p=0.008 n=5+5)
Alloc-4                    182MB/s ± 1%  217MB/s ± 0%  +19.36%  (p=0.004 n=5+6)
```