### PR TITLE
leveldb: add option KeyAffinity to effectively simulate namespace(bucket)

### DIFF
--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -463,6 +463,13 @@ func (b *tableCompactionBuilder) run(cnt *compactionTransactCounter) error {
 			if !hasLastUkey || b.s.icmp.uCompare(lastUkey, ukey) != 0 {
 				// First occurrence of this user key.
 
+				if hasLastUkey && !shouldStop {
+					// also stop if current ukey's affinity is different from lastUkey's
+					if opt := b.s.o; opt.GetKeyAffinity(lastUkey) != opt.GetKeyAffinity(ukey) {
+						shouldStop = true
+					}
+				}
+
 				// Only rotate tables if ukey doesn't hop across.
 				if b.tw != nil && (shouldStop || b.needFlush()) {
 					if err := b.flush(); err != nil {

--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -373,6 +373,16 @@ type Options struct {
 	//
 	// The default value is 8.
 	WriteL0SlowdownTrigger int
+
+	// KeyAffinity defines the function to compute affinity value of the given key.
+	//
+	// Only keys with the same affinity value will appear in the same sst file. So we can use
+	// this option to effectively simulate namespace(bucket).
+	//
+	// ALWAYS use prefix based algorithm to produce affinity value.
+	//
+	// The default value is nil.
+	KeyAffinity func(key []byte) int
 }
 
 func (o *Options) GetAltFilters() []filter.Filter {
@@ -639,6 +649,13 @@ func (o *Options) GetWriteL0SlowdownTrigger() int {
 		return DefaultWriteL0SlowdownTrigger
 	}
 	return o.WriteL0SlowdownTrigger
+}
+
+func (o *Options) GetKeyAffinity(key []byte) int {
+	if o.KeyAffinity != nil {
+		return o.KeyAffinity(key)
+	}
+	return 0
 }
 
 // ReadOptions holds the optional parameters for 'read operation'. The


### PR DESCRIPTION
By this option, we can give different affinity values for stable keys and frequently modified keys,  to significantly reduce compaction IO cost.