### PR TITLE
leveldb: add a Sync method

### DIFF
--- a/leveldb/db_write.go
+++ b/leveldb/db_write.go
@@ -381,6 +381,18 @@ func (db *DB) Delete(key []byte, wo *opt.WriteOptions) error {
 	return db.putRec(keyTypeDel, key, nil, wo)
 }
 
+// Sync syncs the database to disk. All previous puts will persist after a
+// crash, even if they were written with WriteOptions.Sync set to false.
+func (db *DB) Sync() error {
+	if err := db.ok(); err != nil {
+		return err
+	}
+	if db.s.o.GetNoSync() {
+		return nil
+	}
+	return db.journalWriter.Sync()
+}
+
 func isMemOverlaps(icmp *iComparer, mem *memdb.DB, min, max []byte) bool {
 	iter := mem.NewIterator(nil)
 	defer iter.Release()


### PR DESCRIPTION
`Put` + `Sync` is the equivalent of calling `Put` with `WriteOptions.Sync`.

We'd like this method for go-ipfs as we're adding a `Sync(keyPrefix string)` method to our datastore abstraction. We considered adding a `Sync` option to the `Put` method as leveldb does but:

* It's not always possible to know when a write is the "final" write before actually performing the write.
* We'd like to be able to "sync" different sub-datastores independently (i.e., sync everything under `keyPrefix`).