### PR TITLE
leveldb/util: Read buffer pool state atomically

### DIFF
--- a/leveldb/util/buffer_test.go
+++ b/leveldb/util/buffer_test.go
@@ -367,3 +367,46 @@ func BenchmarkBufferFullSmallReads(b *testing.B) {
 		}
 	}
 }
+
+func TestAtomicCopyUint32(t *testing.T) {
+	type testCase struct {
+		description string
+		src         []uint32
+		dst         []uint32
+		expect      int
+	}
+	for _, tc := range []testCase{
+		{
+			description: "CopyNilSrc",
+		},
+		{
+			description: "CopyEqual",
+			src:         []uint32{1, 2, 3},
+			dst:         make([]uint32, 3),
+			expect:      3,
+		},
+		{
+			description: "CopyNilDst",
+			src:         []uint32{1, 2},
+			expect:      0,
+		},
+		{
+			description: "CopyShortSrc",
+			src:         []uint32{1, 2},
+			dst:         make([]uint32, 3),
+			expect:      2,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			n := atomicCopyUint32(tc.dst, tc.src)
+			if tc.expect != n {
+				t.Errorf("expected to copy %d, copied %d", tc.expect, n)
+			}
+			for i := 0; i < n; i++ {
+				if tc.src[i] != tc.dst[i] {
+					t.Errorf("expected src[%d] == dst[%d]; %v == %v", i, i, tc.src[i], tc.dst[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Executing db.GetProperty("leveldb.blockpool") concurrently with BufferPool.Get/Put will lead to data race.
It is probably not a big deal, but definitely an inconvience during tests/e2e simulations.

The easiest way to reproduce a problem is to run following test multile times,e.g:

go test ./leveldb/util/ -count=10 -run=TestConcurrentReads

```go
func TestConcurrentReads(t *testing.T) {
	pool := NewBufferPool(10)
	var wg sync.WaitGroup
	wg.Add(2)
	go func() {
		pool.Get(100)
		wg.Done()
	}()
	go func() {
		pool.String()
		wg.Done()
	}()
	wg.Wait()
}
```

I was able to workaround this race only by coppying buffer pool state atomically (including size* arrays).
Will be glad to know if there are better options.