### PR TITLE
Don't try to acquire database lock if opened in read-only mode

### DIFF
--- a/leveldb/storage/file_storage_test.go
+++ b/leveldb/storage/file_storage_test.go
@@ -364,37 +364,25 @@ func TestFileStorage_ReadOnlyLocking(t *testing.T) {
 	temp := tempDir(t)
 	defer os.RemoveAll(temp)
 
-	p1, err := OpenFile(temp, false)
+	_, err := OpenFile(temp, true)
 	if err != nil {
 		t.Fatal("OpenFile(1): got error: ", err)
 	}
 
-	_, err = OpenFile(temp, true)
+	p2, err := OpenFile(temp, false)
 	if err != nil {
-		t.Logf("OpenFile(2): got error: %s (expected)", err)
-	} else {
-		t.Fatal("OpenFile(2): expect error")
+		t.Fatal("OpenFile(2): got error: ", err)
 	}
 
-	p1.Close()
-
-	p3, err := OpenFile(temp, true)
+	_, err = OpenFile(temp, true)
 	if err != nil {
 		t.Fatal("OpenFile(3): got error: ", err)
 	}
 
-	p4, err := OpenFile(temp, true)
+	p2.Close()
+
+	_, err = OpenFile(temp, true)
 	if err != nil {
 		t.Fatal("OpenFile(4): got error: ", err)
 	}
-
-	_, err = OpenFile(temp, false)
-	if err != nil {
-		t.Logf("OpenFile(5): got error: %s (expected)", err)
-	} else {
-		t.Fatal("OpenFile(2): expect error")
-	}
-
-	p3.Close()
-	p4.Close()
 }


### PR DESCRIPTION
Closes #306 

To be honest, I don't like the fact that the `flock` will be nil when reading databases in read-only mode. A fake/stub lock would be nicer. Anything wanting to use `flock` will need to do a nil check...

Let me know if you have any suggestions.