### PR TITLE
Fix failure to open locked DB in read-only mode on Windows

### DIFF
--- a/leveldb/storage/file_storage_windows.go
+++ b/leveldb/storage/file_storage_windows.go
@@ -37,7 +37,7 @@ func newFileLock(path string, readOnly bool) (fl fileLock, err error) {
 	var access, shareMode uint32
 	if readOnly {
 		access = syscall.GENERIC_READ
-		shareMode = syscall.FILE_SHARE_READ
+		shareMode = syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE
 	} else {
 		access = syscall.GENERIC_READ | syscall.GENERIC_WRITE
 	}


### PR DESCRIPTION
Closes #306 
Originally addressed by PR #315 but this fix feels more correct

This fix also allows all tests to pass on Windows.