### PR TITLE
panic when BytesPrefix failed to represent a prefix with Range

### DIFF
--- a/leveldb/util/range.go
+++ b/leveldb/util/range.go
@@ -28,5 +28,8 @@ func BytesPrefix(prefix []byte) *Range {
 			break
 		}
 	}
+	if limit == nil {
+		panic("BytesPrefix doesn't work for all 0xff prefix")
+	}
 	return &Range{prefix, limit}
 }


### PR DESCRIPTION
`BytesPrefix` won't work for all `0xff` prefix, so panic when it happens.