### PR TITLE
leveldb, manualtest: make filterbaselg configurable

### DIFF
--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -41,6 +41,7 @@ var (
 	DefaultWriteBuffer                   = 4 * MiB
 	DefaultWriteL0PauseTrigger           = 12
 	DefaultWriteL0SlowdownTrigger        = 8
+	DefaultFilterBaseLg                  = 11
 )
 
 // Cacher is a caching algorithm.
@@ -373,6 +374,11 @@ type Options struct {
 	//
 	// The default value is 8.
 	WriteL0SlowdownTrigger int
+
+	// FilterBaseLg is the log size for filter block to create a bloom filter.
+	//
+	// The default value is 11(as well as 2KB)
+	FilterBaseLg int
 }
 
 func (o *Options) GetAltFilters() []filter.Filter {
@@ -639,6 +645,13 @@ func (o *Options) GetWriteL0SlowdownTrigger() int {
 		return DefaultWriteL0SlowdownTrigger
 	}
 	return o.WriteL0SlowdownTrigger
+}
+
+func (o *Options) GetFilterBaseLg() int {
+	if o == nil || o.FilterBaseLg == 0 {
+		return DefaultFilterBaseLg
+	}
+	return o.FilterBaseLg
 }
 
 // ReadOptions holds the optional parameters for 'read operation'. The

--- a/leveldb/table/table.go
+++ b/leveldb/table/table.go
@@ -151,10 +151,6 @@ const (
 	// These constants are part of the file format and should not be changed.
 	blockTypeNoCompression     = 0
 	blockTypeSnappyCompression = 1
-
-	// Generate new filter every 2KB of data
-	filterBaseLg = 11
-	filterBase   = 1 << filterBaseLg
 )
 
 type blockHandle struct {

--- a/leveldb/table/writer.go
+++ b/leveldb/table/writer.go
@@ -89,6 +89,7 @@ type filterWriter struct {
 	buf       util.Buffer
 	nKeys     int
 	offsets   []uint32
+	baseLg    int
 }
 
 func (w *filterWriter) add(key []byte) {
@@ -103,7 +104,7 @@ func (w *filterWriter) flush(offset uint64) {
 	if w.generator == nil {
 		return
 	}
-	for x := int(offset / filterBase); x > len(w.offsets); {
+	for x := int(offset / uint64(1<<w.baseLg)); x > len(w.offsets); {
 		w.generate()
 	}
 }
@@ -122,7 +123,7 @@ func (w *filterWriter) finish() {
 		buf4 := w.buf.Alloc(4)
 		binary.LittleEndian.PutUint32(buf4, x)
 	}
-	w.buf.WriteByte(filterBaseLg)
+	w.buf.WriteByte(byte(w.baseLg))
 }
 
 func (w *filterWriter) generate() {
@@ -369,6 +370,7 @@ func NewWriter(f io.Writer, o *opt.Options) *Writer {
 	// filter block
 	if w.filter != nil {
 		w.filterBlock.generator = w.filter.NewGenerator()
+		w.filterBlock.baseLg = o.GetFilterBaseLg()
 		w.filterBlock.flush(0)
 	}
 	return w

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 	"github.com/syndtr/goleveldb/leveldb/table"
@@ -350,6 +351,7 @@ func main() {
 		DisableBlockCache:      !enableBlockCache,
 		ErrorIfExist:           true,
 		Compression:            opt.NoCompression,
+		Filter:                 filter.NewBloomFilter(10),
 	}
 	if enableCompression {
 		o.Compression = opt.DefaultCompression


### PR DESCRIPTION
This PR makes the log size for filter block to create a new bloom filter configurable.

The main motivation is the extra data of filter block is too large. Let's assume the size of sstable is 2MB, data block size is 4KB and filter size is 2KB(all default value).

Whenever we create a new data block, we will create two bloom filter sections with **2 addition offsets**. The size of offset is 4byte(actually we can use `binary.Uvarint` to reduce the size, but it involves some compatibility issue.

So if the average size of data entry is 200B, then there are 10 entries in this data block. With the `BitsByKey` as 10, then the bloom filter size is 10 * 10 / 8 = 12.5 bytes. BUT the additional offset size is 8byte(yes, we have 2, 1 totally useless). The overhead is not trivial.

With this option, we can change the size(in compatible way), to reduce the overhead.
