### PR TITLE
leveldb, manualtest: introduce metadata cache

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -370,7 +370,7 @@ func recoverTable(s *session, o *opt.Options) error {
 			tgoodKey, tcorruptedKey, tcorruptedBlock int
 			imin, imax                               []byte
 		)
-		tr, err := table.NewReader(reader, size, fd, nil, bpool, o)
+		tr, err := table.NewReader(reader, size, fd, nil, nil, bpool, o)
 		if err != nil {
 			return err
 		}
@@ -1003,6 +1003,12 @@ func (db *DB) GetProperty(name string) (value string, err error) {
 		}
 	case p == "blockpool":
 		value = fmt.Sprintf("%v", db.s.tops.bpool)
+	case p == "cachedmetadata":
+		if db.s.tops.mcache != nil {
+			value = fmt.Sprintf("%d", db.s.tops.mcache.Size())
+		} else {
+			value = "<nil>"
+		}
 	case p == "cachedblock":
 		if db.s.tops.bcache != nil {
 			value = fmt.Sprintf("%d", db.s.tops.bcache.Size())
@@ -1035,6 +1041,7 @@ type DBStats struct {
 	IORead  uint64
 
 	BlockCacheSize    int
+	MetadataCacheSize int
 	OpenedTablesCount int
 
 	LevelSizes        Sizes
@@ -1063,6 +1070,11 @@ func (db *DB) Stats(s *DBStats) error {
 	s.WritePaused = atomic.LoadInt32(&db.inWritePaused) == 1
 
 	s.OpenedTablesCount = db.s.tops.cache.Size()
+	if db.s.tops.mcache != nil {
+		s.MetadataCacheSize = db.s.tops.mcache.Size()
+	} else {
+		s.MetadataCacheSize = 0
+	}
 	if db.s.tops.bcache != nil {
 		s.BlockCacheSize = db.s.tops.bcache.Size()
 	} else {

--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -25,7 +25,7 @@ var (
 	DefaultBlockCacher                   = LRUCacher
 	DefaultBlockCacheCapacity            = 8 * MiB
 	DefaultMetadataCacher                = LRUCacher
-	DefaultMetadataCacheCapacity         = 4 * MiB
+	DefaultMetadataCacheCapacity         = 8 * MiB
 	DefaultOpenFilesCacher               = LRUCacher
 	DefaultOpenFilesCacheCapacity        = 500
 	DefaultBlockRestartInterval          = 16
@@ -169,7 +169,7 @@ type Options struct {
 	// MetadataCacheCapacity defines the capacity of the 'sorted table' metadata caching.
 	// Use -1 for zero, this has same effect as specifying NoCacher to MetadataCacher.
 	//
-	// The default value is 4MiB.
+	// The default value is 8MiB.
 	MetadataCacheCapacity int
 
 	// OpenFilesCacher provides cache algorithm for open files caching.
@@ -437,12 +437,12 @@ func (o *Options) GetBlockCacheCapacity() int {
 }
 
 func (o *Options) GetMetadataCacher() Cacher {
-	if o == nil || o.BlockCacher == nil {
-		return DefaultBlockCacher
-	} else if o.BlockCacher == NoCacher {
+	if o == nil || o.MetadataCacher == nil {
+		return DefaultMetadataCacher
+	} else if o.MetadataCacher == NoCacher {
 		return nil
 	}
-	return o.BlockCacher
+	return o.MetadataCacher
 }
 
 func (o *Options) GetMetadataCacheCapacity() int {

--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -212,11 +212,14 @@ type Options struct {
 	// The default value is false.
 	DisableBlockCache bool
 
-	// DisableMetadataCache allows disable use of cache.Cache functionality on 'sorted table'
-	// block.
+	// EnableMetadataCache allows enable use of cache.Cache functionality on 'sorted table'
+	// metadata by caching them in a separate metadata cache.
+	//
+	// For compatibility consideration, if the metadata cache is disabled, all metadata
+	// will be cached in block cache with user-data if the block cache is enabled.
 	//
 	// The default value is false.
-	DisableMetadataCache bool
+	EnableMetadataCache bool
 
 	// BlockRestartInterval is the number of keys between restart points for
 	// delta encoding of keys.
@@ -500,11 +503,11 @@ func (o *Options) GetDisableBlockCache() bool {
 	return o.DisableBlockCache
 }
 
-func (o *Options) GetDisableMetadataCache() bool {
+func (o *Options) GetEnableMetadataCache() bool {
 	if o == nil {
 		return false
 	}
-	return o.DisableMetadataCache
+	return o.EnableMetadataCache
 }
 
 func (o *Options) GetBlockRestartInterval() int {

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -357,12 +357,27 @@ func (x *tFilesSortByNum) Less(i, j int) bool {
 
 // Table operations.
 type tOps struct {
-	s            *session
-	noSync       bool
+	s      *session
+	noSync bool
+
+	// evictBlockRemoved is an option to evict cached block data when the
+	// file is removed by compaction.
+	//
+	// The option is deprecated, keep it here for backward compatibility
+	evictBlockRemoved bool
+
+	// addCreated is an option to cache the opened file handler and metadata
+	// when the file is created by compaction.
+	addCreated bool
+
+	// evictRemoved is an option to evict the metadata and all cached blocks
+	// when the file is removed by compaction
 	evictRemoved bool
-	cache        *cache.Cache
-	bcache       *cache.Cache
-	bpool        *util.BufferPool
+
+	cache  *cache.Cache
+	mcache *cache.Cache
+	bcache *cache.Cache
+	bpool  *util.BufferPool
 }
 
 // Creates an empty table and returns table writer.
@@ -418,20 +433,23 @@ func (t *tOps) open(f *tFile) (ch *cache.Handle, err error) {
 		if err != nil {
 			return 0, nil
 		}
-
-		var bcache *cache.NamespaceGetter
+		var (
+			mcache *cache.NamespaceGetter
+			bcache *cache.NamespaceGetter
+		)
+		if t.mcache != nil {
+			mcache = &cache.NamespaceGetter{Cache: t.mcache, NS: uint64(f.fd.Num)}
+		}
 		if t.bcache != nil {
 			bcache = &cache.NamespaceGetter{Cache: t.bcache, NS: uint64(f.fd.Num)}
 		}
-
 		var tr *table.Reader
-		tr, err = table.NewReader(r, f.size, f.fd, bcache, t.bpool, t.s.o.Options)
+		tr, err = table.NewReader(r, f.size, f.fd, mcache, bcache, t.bpool, t.s.o.Options)
 		if err != nil {
 			r.Close()
 			return 0, nil
 		}
 		return 1, tr
-
 	})
 	if ch == nil && err == nil {
 		err = ErrClosed
@@ -490,12 +508,47 @@ func (t *tOps) remove(fd storage.FileDesc) {
 		} else {
 			t.s.logf("table@remove removed @%d", fd.Num)
 		}
-		if t.evictRemoved && t.bcache != nil {
+		if (t.evictRemoved || t.evictBlockRemoved) && t.bcache != nil {
 			t.bcache.EvictNS(uint64(fd.Num))
+		}
+		if t.evictRemoved && t.mcache != nil {
+			t.mcache.EvictNS(uint64(fd.Num))
+		}
+		if t.evictRemoved && t.cache != nil {
+			t.cache.Evict(0, uint64(fd.Num))
 		}
 		// Try to reuse file num, useful for discarded transaction.
 		t.s.reuseFileNum(fd.Num)
 	})
+}
+
+// cacheCommittedWriter takes a committed writer and cache it.
+func (t *tOps) cacheCommittedWriter(w *tWriter) error {
+	if !t.addCreated || t.cache == nil {
+		return nil
+	}
+	r, err := t.s.stor.Open(w.fd)
+	if err != nil {
+		return err
+	}
+	var (
+		mcache *cache.NamespaceGetter
+		bcache *cache.NamespaceGetter
+	)
+	if t.mcache != nil {
+		mcache = &cache.NamespaceGetter{Cache: t.mcache, NS: uint64(w.fd.Num)}
+	}
+	if t.bcache != nil {
+		bcache = &cache.NamespaceGetter{Cache: t.bcache, NS: uint64(w.fd.Num)}
+	}
+	reader, err := w.tw.ToReader(r, w.fd, mcache, bcache, t.bpool, t.s.o.Options)
+	if err != nil {
+		return err
+	}
+	t.cache.Get(0, uint64(w.fd.Num), func() (size int, value cache.Value) {
+		return 1, reader
+	})
+	return nil
 }
 
 // Closes the table ops instance. It will close all tables,
@@ -506,17 +559,28 @@ func (t *tOps) close() {
 	if t.bcache != nil {
 		t.bcache.CloseWeak()
 	}
+	if t.mcache != nil {
+		t.mcache.CloseWeak()
+	}
 }
 
 // Creates new initialized table ops instance.
 func newTableOps(s *session) *tOps {
 	var (
 		cacher cache.Cacher
+		mcache *cache.Cache
 		bcache *cache.Cache
 		bpool  *util.BufferPool
 	)
 	if s.o.GetOpenFilesCacheCapacity() > 0 {
-		cacher = cache.NewLRU(s.o.GetOpenFilesCacheCapacity())
+		cacher = s.o.GetOpenFilesCacher().New(s.o.GetOpenFilesCacheCapacity())
+	}
+	if !s.o.GetDisableMetadataCache() {
+		var mcacher cache.Cacher
+		if s.o.GetMetadataCacheCapacity() > 0 {
+			mcacher = s.o.GetMetadataCacher().New(s.o.GetMetadataCacheCapacity())
+		}
+		mcache = cache.NewCache(mcacher)
 	}
 	if !s.o.GetDisableBlockCache() {
 		var bcacher cache.Cacher
@@ -529,17 +593,21 @@ func newTableOps(s *session) *tOps {
 		bpool = util.NewBufferPool(s.o.GetBlockSize() + 5)
 	}
 	return &tOps{
-		s:            s,
-		noSync:       s.o.GetNoSync(),
-		evictRemoved: s.o.GetBlockCacheEvictRemoved(),
-		cache:        cache.NewCache(cacher),
-		bcache:       bcache,
-		bpool:        bpool,
+		s:                 s,
+		noSync:            s.o.GetNoSync(),
+		evictBlockRemoved: s.o.GetBlockCacheEvictRemoved(),
+		addCreated:        s.o.GetCacheAddCreated(),
+		evictRemoved:      s.o.GetCacheEvictRemoved(),
+		cache:             cache.NewCache(cacher),
+		mcache:            mcache,
+		bcache:            bcache,
+		bpool:             bpool,
 	}
 }
 
 // tWriter wraps the table writer. It keep track of file descriptor
-// and added key range.
+// and added key range. Also it's also responsible for caching newly
+// created file if required.
 type tWriter struct {
 	t *tOps
 
@@ -585,7 +653,8 @@ func (w *tWriter) finish() (f *tFile, err error) {
 			return
 		}
 	}
-	f = newTableFile(w.fd, int64(w.tw.BytesLen()), internalKey(w.first), internalKey(w.last))
+	f = newTableFile(w.fd, int64(w.tw.BytesLen()), w.first, w.last)
+	w.t.cacheCommittedWriter(w) // Cache the newly created file
 	return
 }
 

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -437,8 +437,12 @@ func (t *tOps) open(f *tFile) (ch *cache.Handle, err error) {
 			mcache *cache.NamespaceGetter
 			bcache *cache.NamespaceGetter
 		)
+		// Cache metadata in a separate cache instance if metadata cache is enabled.
+		// Otherwise, mix them with the user-data for backward compatibility.
 		if t.mcache != nil {
 			mcache = &cache.NamespaceGetter{Cache: t.mcache, NS: uint64(f.fd.Num)}
+		} else if t.bcache != nil {
+			mcache = &cache.NamespaceGetter{Cache: t.bcache, NS: uint64(f.fd.Num)}
 		}
 		if t.bcache != nil {
 			bcache = &cache.NamespaceGetter{Cache: t.bcache, NS: uint64(f.fd.Num)}
@@ -535,8 +539,12 @@ func (t *tOps) cacheCommittedWriter(w *tWriter) error {
 		mcache *cache.NamespaceGetter
 		bcache *cache.NamespaceGetter
 	)
+	// Cache metadata in a separate cache instance if metadata cache is enabled.
+	// Otherwise, mix them with the user-data for backward compatibility.
 	if t.mcache != nil {
 		mcache = &cache.NamespaceGetter{Cache: t.mcache, NS: uint64(w.fd.Num)}
+	} else if t.bcache != nil {
+		mcache = &cache.NamespaceGetter{Cache: t.bcache, NS: uint64(w.fd.Num)}
 	}
 	if t.bcache != nil {
 		bcache = &cache.NamespaceGetter{Cache: t.bcache, NS: uint64(w.fd.Num)}
@@ -575,7 +583,7 @@ func newTableOps(s *session) *tOps {
 	if s.o.GetOpenFilesCacheCapacity() > 0 {
 		cacher = s.o.GetOpenFilesCacher().New(s.o.GetOpenFilesCacheCapacity())
 	}
-	if !s.o.GetDisableMetadataCache() {
+	if s.o.GetEnableMetadataCache() {
 		var mcacher cache.Cacher
 		if s.o.GetMetadataCacheCapacity() > 0 {
 			mcacher = s.o.GetMetadataCacher().New(s.o.GetMetadataCacheCapacity())

--- a/leveldb/table/table_test.go
+++ b/leveldb/table/table_test.go
@@ -60,7 +60,7 @@ var _ = testutil.Defer(func() {
 			It("Should be able to approximate offset of a key correctly", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
-				tr, err := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()), storage.FileDesc{}, nil, nil, o)
+				tr, err := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()), storage.FileDesc{}, nil, nil, nil, o)
 				Expect(err).ShouldNot(HaveOccurred())
 				CheckOffset := func(key string, expect, threshold int) {
 					offset, err := tr.OffsetOf([]byte(key))
@@ -97,7 +97,7 @@ var _ = testutil.Defer(func() {
 				tw.Close()
 
 				// Opening the table.
-				tr, _ := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()), storage.FileDesc{}, nil, nil, o)
+				tr, _ := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()), storage.FileDesc{}, nil, nil, nil, o)
 				return tableWrapper{tr}
 			}
 			Test := func(kv *testutil.KeyValue, body func(r *Reader)) func() {

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -170,7 +170,7 @@ func (ts *testingStorage) scanTable(fd storage.FileDesc, checksum bool) (corrupt
 	if checksum {
 		o.Strict = opt.StrictBlockChecksum | opt.StrictReader
 	}
-	tr, err := table.NewReader(r, size, fd, nil, bpool, o)
+	tr, err := table.NewReader(r, size, fd, nil, nil, bpool, o)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds a new type cache `metadata cache`.

We all know that leveldb has an awesome write performance. But for reading, it's a little bit slower. The main reason is a single reading operation may involve multi-files.

For level0, we need to iterate the files from new to old; for non-0-level,  we need to iterate a specific file. So we may need to touch multi-files while reading a single entry.

### How can we speed up the reading?

Reduce access to the disk.

In the leveldb, each sstable file has some metadata includes index block(and may include the filter block). Index block can help to locate the potential position of the target entry in the file . Filter block can help to determine whether the file has the target entry. If not, we don't need to access the data block at all. 

Every time when we try to find an entry in a sstable file, we will first load these metadata. But the metadata is not trivial(~30KB for 2MB file). If we can't cache them meaningfully, we will re-read these metadata over and over again.

### Why introduce the metadata cache?

In some special scenarios, data caching is totally useless. E.g. in the ethereum, there are 500M entries with random key(hash). If we cache the user data in the `BlockCache`, it has a very high chance that the cache will never be hit. *But the metadata caching is useful!*. The average size of metadata(the filter block and index block) is around 30KB, if we allocate 1GB cache for metadata only, it means we can maintain most of the metadata in the memory. But now the filter block and index block are mixed with the user data in `BlockCache`. So the user data will occupy the space of metadata.

Therefore, the metadata will be kicked out and re-read over and over again. The read amplification is high in this case.

### Why not using `DontFillCache`?

Because a lot of systems have their own database abstraction. It's much easier to specify the metadata cache and data cache separately instead of introducing complicated notions into the interface.

### What's more?

Besides, this PR introduces two additional configs: `CacheEvictRemoved` and `CacheAddCreated`. Whenever the file is removed by compaction, evict all cached data(including the open file cache and metadata) from the cache. Whenever the file is created by compaction, cache the file handler and metadata into the cache.

