### PR TITLE
leveldb: fix write operation suspension

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/syndtr/goleveldb
 
+go 1.14
+
 require (
 	github.com/golang/snappy v0.0.1
 	github.com/onsi/ginkgo v1.7.0

--- a/leveldb/db_write.go
+++ b/leveldb/db_write.go
@@ -85,6 +85,7 @@ func (db *DB) flush(n int) (mdb *memDB, mdbFree int, err error) {
 		case tLen >= slowdownTrigger && !delayed:
 			delayed = true
 			time.Sleep(time.Millisecond)
+			return false
 		case mdbFree >= n:
 			return false
 		case tLen >= pauseTrigger:


### PR DESCRIPTION
Hi @syndtr Here is an easy fix for write suspension.

We have this mechanism to slow down write operations if there are too many LEVEL0 files accumulated.
But instead of writing a Millisecond then resume the write, we will "deadloop" until the SLOW DOWN
alert is resolved.

I'm not sure how much performance affect this issue will have(e.g. deadloop will definitely exhaust one CPU core),
but I think it's quite easy to fix. So please take a look.