### PR TITLE
leveldb/opt: add VibrantKeys option

### DIFF
--- a/leveldb/session.go
+++ b/leveldb/session.go
@@ -63,6 +63,8 @@ type session struct {
 	closeW      sync.WaitGroup
 	vmu         sync.Mutex
 
+	maxVibrantTableLevel int // known max level of table that contains vibrant keys
+
 	// Testing fields
 	fileRefCh chan chan map[int64]int // channel used to pass current reference stat
 }


### PR DESCRIPTION
to optimize disk space usage for cases that have frequent key updates and deletions