### PR TITLE
Add fsync after creating new manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: go
 
 go:
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
+  - 1.14.x
+  - 1.15.x
   - tip
 
 script:
-  - go vet ./...
+  - |
+    (set -e
+    if [ "$TRAVIS_GO_VERSION" != "tip" ]; then 
+      echo "executing go vet for go verion $TRAVIS_GO_VERSION"
+      go vet ./...
+    else
+      echo "skipping go vet for go verion $TRAVIS_GO_VERSION"
+    fi
+    )
   - go test -timeout 1h ./...
   - go test -timeout 30m -race -run "TestDB_(Concurrent|GoleveldbIssue74)" ./leveldb

--- a/leveldb/session_util.go
+++ b/leveldb/session_util.go
@@ -453,6 +453,12 @@ func (s *session) newManifest(rec *sessionRecord, v *version) (err error) {
 	if err != nil {
 		return
 	}
+	if !s.o.GetNoSync() {
+		err = writer.Sync()
+		if err != nil {
+			return
+		}
+	}
 	err = s.stor.SetMeta(fd)
 	return
 }


### PR DESCRIPTION
This simple PR adds an fsync call on the manifest file when a new
manifest file is generated at the start.

In absence of this, the code updates the "CURRENT" and deletes the
previous manifest file and a crash at this point could leave the latest
manifest with a single incomplete record. With this content in the manifest file,
a restart is expected to lead to [manifest corrupt error](https://github.com/syndtr/goleveldb/blob/5c35d600f0caac04c20d52438103f1a7aa612598/leveldb/session.go#L192)
This seems to explain the error observed in issue #335. We too have observed this error in our environment.

closes #335.