### PR TITLE
table: make better use of already allocated memory for snap compression

### DIFF
--- a/leveldb/table/writer.go
+++ b/leveldb/table/writer.go
@@ -166,7 +166,10 @@ func (w *Writer) writeBlock(buf *util.Buffer, compression opt.Compression) (bh b
 	if compression == opt.SnappyCompression {
 		// Allocate scratch enough for compression and block trailer.
 		if n := snappy.MaxEncodedLen(buf.Len()) + blockTrailerLen; len(w.compressionScratch) < n {
-			w.compressionScratch = make([]byte, n)
+			if cap(w.compressionScratch) < n {
+				w.compressionScratch = make([]byte, n)
+			}
+			w.compressionScratch = w.compressionScratch[:n]
 		}
 		compressed := snappy.Encode(w.compressionScratch, buf.Bytes())
 		n := len(compressed)


### PR DESCRIPTION
I stumbled upon this trick when I tried to optimize some memory allocation in go-ethereum, and checked to see if goleveldb was using the same mechanism of checking how much the `snappy` library would need, to be able to avoid the full alloc inside `snappy.Encode`. 
 
Turns out it did, almost -- however the check only checked the `length` of the scratch buffer, not the `cap`. If the `cap` is sufficient, we can just grow it and avoid a realloc. 

Some (random) benchmarks shows that it seems to improve things a bit. 

```
name                        old time/op    new time/op    delta
DBWrite-6                     3.30µs ± 4%    3.21µs ± 1%  -2.69%  (p=0.016 n=5+5)
DBWriteBatch-6                 694ns ±19%     679ns ±13%    ~     (p=0.881 n=5+5)
DBWriteUncompressed-6         3.33µs ± 3%    3.37µs ± 8%    ~     (p=1.000 n=5+5)
DBWriteBatchUncompressed-6     651ns ± 1%     665ns ±10%    ~     (p=1.000 n=4+5)
DBWriteRandom-6               4.42µs ± 3%    4.46µs ± 4%    ~     (p=0.690 n=5+5)
DBWriteRandomSync-6           3.91µs ± 2%    3.91µs ± 1%    ~     (p=0.730 n=5+4)

name                        old speed      new speed      delta
DBWrite-6                   35.2MB/s ± 4%  36.1MB/s ± 1%  +2.71%  (p=0.016 n=5+5)
DBWriteBatch-6               169MB/s ±17%   171MB/s ±12%    ~     (p=0.841 n=5+5)
DBWriteUncompressed-6       34.8MB/s ± 3%  34.5MB/s ± 7%    ~     (p=1.000 n=5+5)
DBWriteBatchUncompressed-6   178MB/s ± 1%   175MB/s ± 9%    ~     (p=1.000 n=4+5)
DBWriteRandom-6             26.2MB/s ± 3%  26.0MB/s ± 4%    ~     (p=0.690 n=5+5)
DBWriteRandomSync-6         29.6MB/s ± 2%  29.7MB/s ± 1%    ~     (p=0.730 n=5+4)

name                        old alloc/op   new alloc/op   delta
DBWrite-6                       150B ± 5%      147B ± 2%    ~     (p=0.333 n=5+5)
DBWriteBatch-6                 21.0B ± 0%     21.0B ± 0%    ~     (all equal)
DBWriteUncompressed-6           151B ± 7%      149B ± 2%    ~     (p=0.849 n=5+5)
DBWriteBatchUncompressed-6     20.0B ± 0%     20.0B ± 0%    ~     (all equal)
DBWriteRandom-6                 184B ± 2%      185B ± 1%    ~     (p=0.357 n=5+5)
DBWriteRandomSync-6             168B ± 4%      170B ± 9%    ~     (p=0.508 n=5+5)

name                        old allocs/op  new allocs/op  delta
DBWrite-6                       3.00 ± 0%      3.00 ± 0%    ~     (all equal)
DBWriteBatch-6                  0.00           0.00         ~     (all equal)
DBWriteUncompressed-6           3.00 ± 0%      3.00 ± 0%    ~     (all equal)
DBWriteBatchUncompressed-6      0.00           0.00         ~     (all equal)
DBWriteRandom-6                 3.00 ± 0%      3.00 ± 0%    ~     (all equal)
DBWriteRandomSync-6             3.00 ± 0%      3.00 ± 0%    ~     (all equal)
```