### PR TITLE
no space left on device:  Service must be restarted

### DIFF
--- a/leveldb/errors/errors.go
+++ b/leveldb/errors/errors.go
@@ -10,6 +10,7 @@ package errors
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/syndtr/goleveldb/leveldb/storage"
 	"github.com/syndtr/goleveldb/leveldb/util"
@@ -75,4 +76,16 @@ func SetFd(err error, fd storage.FileDesc) error {
 		return x
 	}
 	return err
+}
+
+// IsUnrecoverableError Determine whether there is no need to restart the error that can be repaired
+// for example, the disk is full. This error is a fixable error
+func IsUnrecoverableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), "no space left on device") {
+		return false
+	}
+	return true
 }

--- a/leveldb/journal/journal.go
+++ b/leveldb/journal/journal.go
@@ -407,7 +407,7 @@ func (w *Writer) writeBlock() {
 // writePending finishes the current journal and writes the buffer to the
 // underlying writer.
 func (w *Writer) writePending() {
-	if w.err != nil {
+	if errors.IsUnrecoverableError(w.err) {
 		return
 	}
 	if w.pending {
@@ -422,7 +422,7 @@ func (w *Writer) writePending() {
 func (w *Writer) Close() error {
 	w.seq++
 	w.writePending()
-	if w.err != nil {
+	if errors.IsUnrecoverableError(w.err) {
 		return w.err
 	}
 	w.err = errors.New("leveldb/journal: closed Writer")
@@ -434,7 +434,7 @@ func (w *Writer) Close() error {
 func (w *Writer) Flush() error {
 	w.seq++
 	w.writePending()
-	if w.err != nil {
+	if errors.IsUnrecoverableError(w.err) {
 		return w.err
 	}
 	if w.f != nil {
@@ -467,7 +467,7 @@ func (w *Writer) Reset(writer io.Writer) (err error) {
 // after the next Close, Flush or Next call, and should no longer be used.
 func (w *Writer) Next() (io.Writer, error) {
 	w.seq++
-	if w.err != nil {
+	if errors.IsUnrecoverableError(w.err) {
 		return nil, w.err
 	}
 	if w.pending {
@@ -501,7 +501,7 @@ func (x singleWriter) Write(p []byte) (int, error) {
 	if w.seq != x.seq {
 		return 0, errors.New("leveldb/journal: stale writer")
 	}
-	if w.err != nil {
+	if errors.IsUnrecoverableError(w.err) {
 		return 0, w.err
 	}
 	n0 := len(p)

--- a/leveldb/table/writer.go
+++ b/leveldb/table/writer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang/snappy"
 
 	"github.com/syndtr/goleveldb/leveldb/comparer"
+	lerrors "github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
@@ -236,7 +237,7 @@ func (w *Writer) finishBlock() error {
 //
 // It is safe to modify the contents of the arguments after Append returns.
 func (w *Writer) Append(key, value []byte) error {
-	if w.err != nil {
+	if lerrors.IsUnrecoverableError(w.err) {
 		return w.err
 	}
 	if w.nEntries > 0 && w.cmp.Compare(w.dataBlock.prevKey, key) >= 0 {
@@ -285,7 +286,7 @@ func (w *Writer) BytesLen() int {
 // after Close, but calling BlocksLen, EntriesLen and BytesLen
 // is still possible.
 func (w *Writer) Close() error {
-	if w.err != nil {
+	if lerrors.IsUnrecoverableError(w.err) {
 		return w.err
 	}
 


### PR DESCRIPTION
# background：
We encountered the "no space left on device" error. After cleaning up the disk space, it still keeps reporting this error. I hope this error does not need to restart the service.

-------
I found that the writer will store the error information in w.err. 
When the operation starts, it will first judge w.err != nil. If w.err is an error that can be recovered manually, you can skip the error judgment at the entry first.

Make a suggestion, hope to adopt
thanks
