### PR TITLE
util/buffer_pool, db: Reduce memory allocation

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -319,7 +319,7 @@ func recoverTable(s *session, o *opt.Options) error {
 		}()
 
 		// Copy entries.
-		tw := table.NewWriter(writer, o)
+		tw := table.NewWriter(writer, o, nil, 0)
 		for iter.Next() {
 			key := iter.Key()
 			if validInternalKey(key) {

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -389,7 +389,7 @@ func (b *tableCompactionBuilder) appendKV(key, value []byte) error {
 
 		// Create new table.
 		var err error
-		b.tw, err = b.s.tops.create()
+		b.tw, err = b.s.tops.create(b.tableSize)
 		if err != nil {
 			return err
 		}

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -2539,7 +2539,7 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 		value      = bytes.Repeat([]byte{'0'}, 100)
 	)
 	for i := 0; i < 2; i++ {
-		tw, err := s.tops.create()
+		tw, err := s.tops.create(0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -366,7 +366,7 @@ type tOps struct {
 }
 
 // Creates an empty table and returns table writer.
-func (t *tOps) create() (*tWriter, error) {
+func (t *tOps) create(tSize int) (*tWriter, error) {
 	fd := storage.FileDesc{Type: storage.TypeTable, Num: t.s.allocFileNum()}
 	fw, err := t.s.stor.Create(fd)
 	if err != nil {
@@ -376,13 +376,13 @@ func (t *tOps) create() (*tWriter, error) {
 		t:  t,
 		fd: fd,
 		w:  fw,
-		tw: table.NewWriter(fw, t.s.o.Options),
+		tw: table.NewWriter(fw, t.s.o.Options, t.bpool, tSize),
 	}, nil
 }
 
 // Builds table from src iterator.
 func (t *tOps) createFrom(src iterator.Iterator) (f *tFile, n int, err error) {
-	w, err := t.create()
+	w, err := t.create(0)
 	if err != nil {
 		return
 	}

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -501,7 +501,6 @@ func (t *tOps) remove(fd storage.FileDesc) {
 // Closes the table ops instance. It will close all tables,
 // regadless still used or not.
 func (t *tOps) close() {
-	t.bpool.Close()
 	t.cache.Close()
 	if t.bcache != nil {
 		t.bcache.CloseWeak()

--- a/leveldb/table/table_test.go
+++ b/leveldb/table/table_test.go
@@ -47,7 +47,7 @@ var _ = testutil.Defer(func() {
 			)
 
 			// Building the table.
-			tw := NewWriter(buf, o)
+			tw := NewWriter(buf, o, nil, 0)
 			tw.Append([]byte("k01"), []byte("hello"))
 			tw.Append([]byte("k02"), []byte("hello2"))
 			tw.Append([]byte("k03"), bytes.Repeat([]byte{'x'}, 10000))
@@ -90,7 +90,7 @@ var _ = testutil.Defer(func() {
 				buf := &bytes.Buffer{}
 
 				// Building the table.
-				tw := NewWriter(buf, o)
+				tw := NewWriter(buf, o, nil, 0)
 				kv.Iterate(func(i int, key, value []byte) {
 					tw.Append(key, value)
 				})

--- a/leveldb/util/buffer_pool.go
+++ b/leveldb/util/buffer_pool.go
@@ -10,30 +10,15 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 )
-
-type buffer struct {
-	b    []byte
-	miss int
-}
 
 // BufferPool is a 'buffer pool'.
 type BufferPool struct {
-	pool      [6]chan []byte
-	size      [5]uint32
-	sizeMiss  [5]uint32
-	sizeHalf  [5]uint32
-	baseline  [4]int
-	baseline0 int
-
-	mu     sync.RWMutex
-	closed bool
-	closeC chan struct{}
+	pool     [6]sync.Pool
+	baseline [5]int
 
 	get     uint32
 	put     uint32
-	half    uint32
 	less    uint32
 	equal   uint32
 	greater uint32
@@ -41,15 +26,12 @@ type BufferPool struct {
 }
 
 func (p *BufferPool) poolNum(n int) int {
-	if n <= p.baseline0 && n > p.baseline0/2 {
-		return 0
-	}
 	for i, x := range p.baseline {
 		if n <= x {
-			return i + 1
+			return i
 		}
 	}
-	return len(p.baseline) + 1
+	return len(p.baseline)
 }
 
 // Get returns buffer with length of n.
@@ -57,101 +39,47 @@ func (p *BufferPool) Get(n int) []byte {
 	if p == nil {
 		return make([]byte, n)
 	}
-
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-
-	if p.closed {
-		return make([]byte, n)
-	}
-
 	atomic.AddUint32(&p.get, 1)
 
 	poolNum := p.poolNum(n)
-	pool := p.pool[poolNum]
-	if poolNum == 0 {
-		// Fast path.
-		select {
-		case b := <-pool:
-			switch {
-			case cap(b) > n:
-				if cap(b)-n >= n {
-					atomic.AddUint32(&p.half, 1)
-					select {
-					case pool <- b:
-					default:
-					}
-					return make([]byte, n)
-				} else {
-					atomic.AddUint32(&p.less, 1)
-					return b[:n]
-				}
-			case cap(b) == n:
-				atomic.AddUint32(&p.equal, 1)
-				return b[:n]
-			default:
-				atomic.AddUint32(&p.greater, 1)
-			}
-		default:
-			atomic.AddUint32(&p.miss, 1)
+
+	b := p.pool[poolNum].Get().(*[]byte)
+
+	if cap(*b) == 0 {
+		// If we grabbed nothing, increment the miss stats.
+		atomic.AddUint32(&p.miss, 1)
+
+		if poolNum == len(p.baseline) {
+			*b = make([]byte, n)
+			return *b
 		}
 
-		return make([]byte, n, p.baseline0)
+		*b = make([]byte, p.baseline[poolNum])
+		*b = (*b)[:n]
+		return *b
 	} else {
-		sizePtr := &p.size[poolNum-1]
-
-		select {
-		case b := <-pool:
-			switch {
-			case cap(b) > n:
-				if cap(b)-n >= n {
-					atomic.AddUint32(&p.half, 1)
-					sizeHalfPtr := &p.sizeHalf[poolNum-1]
-					if atomic.AddUint32(sizeHalfPtr, 1) == 20 {
-						atomic.StoreUint32(sizePtr, uint32(cap(b)/2))
-						atomic.StoreUint32(sizeHalfPtr, 0)
-					} else {
-						select {
-						case pool <- b:
-						default:
-						}
-					}
-					return make([]byte, n)
-				} else {
-					atomic.AddUint32(&p.less, 1)
-					return b[:n]
-				}
-			case cap(b) == n:
-				atomic.AddUint32(&p.equal, 1)
-				return b[:n]
-			default:
-				atomic.AddUint32(&p.greater, 1)
-				if uint32(cap(b)) >= atomic.LoadUint32(sizePtr) {
-					select {
-					case pool <- b:
-					default:
-					}
-				}
-			}
-		default:
-			atomic.AddUint32(&p.miss, 1)
-		}
-
-		if size := atomic.LoadUint32(sizePtr); uint32(n) > size {
-			if size == 0 {
-				atomic.CompareAndSwapUint32(sizePtr, 0, uint32(n))
-			} else {
-				sizeMissPtr := &p.sizeMiss[poolNum-1]
-				if atomic.AddUint32(sizeMissPtr, 1) == 20 {
-					atomic.StoreUint32(sizePtr, uint32(n))
-					atomic.StoreUint32(sizeMissPtr, 0)
-				}
-			}
-			return make([]byte, n)
-		} else {
-			return make([]byte, n, size)
+		// If there is enough capacity in the bytes grabbed, resize the length
+		// to n and return.
+		if n < cap(*b) {
+			atomic.AddUint32(&p.less, 1)
+			*b = (*b)[:n]
+			return *b
+		} else if n == cap(*b) {
+			atomic.AddUint32(&p.equal, 1)
+			*b = (*b)[:n]
+			return *b
+		} else if n > cap(*b) {
+			atomic.AddUint32(&p.greater, 1)
 		}
 	}
+
+	if poolNum == len(p.baseline) {
+		*b = make([]byte, n)
+		return *b
+	}
+	*b = make([]byte, p.baseline[poolNum])
+	*b = (*b)[:n]
+	return *b
 }
 
 // Put adds given buffer to the pool.
@@ -160,68 +88,18 @@ func (p *BufferPool) Put(b []byte) {
 		return
 	}
 
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-
-	if p.closed {
-		return
-	}
+	poolNum := p.poolNum(cap(b))
 
 	atomic.AddUint32(&p.put, 1)
-
-	pool := p.pool[p.poolNum(cap(b))]
-	select {
-	case pool <- b:
-	default:
-	}
-
-}
-
-func (p *BufferPool) Close() {
-	if p == nil {
-		return
-	}
-
-	p.mu.Lock()
-	if !p.closed {
-		p.closed = true
-		p.closeC <- struct{}{}
-	}
-	p.mu.Unlock()
+	p.pool[poolNum].Put(&b)
 }
 
 func (p *BufferPool) String() string {
 	if p == nil {
 		return "<nil>"
 	}
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	return fmt.Sprintf("BufferPool{B·%d Z·%v Zm·%v Zh·%v G·%d P·%d H·%d <·%d =·%d >·%d M·%d}",
-		p.baseline0, p.size, p.sizeMiss, p.sizeHalf, p.get, p.put, p.half, p.less, p.equal, p.greater, p.miss)
-}
-
-func (p *BufferPool) drain() {
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			for _, ch := range p.pool {
-				select {
-				case <-ch:
-				default:
-				}
-			}
-		case <-p.closeC:
-			close(p.closeC)
-			for _, ch := range p.pool {
-				close(ch)
-			}
-			return
-		}
-	}
+	return fmt.Sprintf("BufferPool{B·%d G·%d P·%d <·%d =·%d >·%d M·%d}",
+		p.baseline, p.get, p.put, p.less, p.equal, p.greater, p.miss)
 }
 
 // NewBufferPool creates a new initialized 'buffer pool'.
@@ -229,14 +107,29 @@ func NewBufferPool(baseline int) *BufferPool {
 	if baseline <= 0 {
 		panic("baseline can't be <= 0")
 	}
-	p := &BufferPool{
-		baseline0: baseline,
-		baseline:  [...]int{baseline / 4, baseline / 2, baseline * 2, baseline * 4},
-		closeC:    make(chan struct{}, 1),
+	bufPool := &BufferPool{
+		baseline: [...]int{baseline / 4, baseline / 2, baseline, baseline * 2, baseline * 4},
+		pool: [6]sync.Pool{
+			sync.Pool{
+				New: func() interface{} { return new([]byte) },
+			},
+			sync.Pool{
+				New: func() interface{} { return new([]byte) },
+			},
+			sync.Pool{
+				New: func() interface{} { return new([]byte) },
+			},
+			sync.Pool{
+				New: func() interface{} { return new([]byte) },
+			},
+			sync.Pool{
+				New: func() interface{} { return new([]byte) },
+			},
+			sync.Pool{
+				New: func() interface{} { return new([]byte) },
+			},
+		},
 	}
-	for i, cap := range []int{2, 2, 4, 4, 2, 1} {
-		p.pool[i] = make(chan []byte, cap)
-	}
-	go p.drain()
-	return p
+
+	return bufPool
 }


### PR DESCRIPTION
This PR addresses the problem of too much memory being allocated by goleveldb in the project I'm working on here: https://github.com/mit-dci/utcd.

I've conducted two benchmarks to check that this PR lessen the memory allocated:
1: pprof results from the project I'm working on.
2: Benchstat results from the existing benchmark tests in goleveldb.

# pprof results

The project I'm working on is a Bitcoin node in Go. It uses goleveldb to keep track of Bitcoins that are available to be spent. The load on goleveldb is very intense with there being many reads and writes when it first starts up. I used this command to create a controlled test for profiling the memory usage. 

```
# only the --memprofile flag differs for old goleveldb test
timeout -s SIGINT 20m ./btcd --logdir=. --datadir=. --memprofile=memprof-new-goleveldb --connect=127.0.0.1
```

The binary used was compiled from branch `utreexo` on commit `e1ab5c048f37e714b46e94782c4e2a66319962f2`

## pprof-top results

Before, `BufferPool.Get()` allocated the most memory. 45.19% of all memory allocated was allocated by it.
After, `BufferPool.Get()` only allocated 9.12%.

old:
![Screen Shot 2021-08-17 at 6 24 39 PM](https://user-images.githubusercontent.com/37185887/129700238-4c4573b7-c3cd-486a-a902-7f9b6f08f5b6.png)

new:
![Screen Shot 2021-08-17 at 6 28 20 PM](https://user-images.githubusercontent.com/37185887/129700816-52bb8b9c-d11f-4a3f-8d0a-0cd9657c6fab.png)

## pprof-flame results

The difference of the memory allocated between these two can be visibly seen on the flamegraph as well.

old:
![Screen Shot 2021-08-17 at 6 33 13 PM](https://user-images.githubusercontent.com/37185887/129701613-4df2fb98-ef26-45d4-90a9-7fb20edf7af4.png)

new:
![Screen Shot 2021-08-17 at 6 34 27 PM](https://user-images.githubusercontent.com/37185887/129701789-ba12da9c-6c20-48a1-b627-eb66dc9416bc.png)

I've included the html files for the pprof images used above as well as the html files for pprof-graph
[pprof goleveldb.zip](https://github.com/syndtr/goleveldb/files/6998530/pprof.goleveldb.zip)

# Benchstat results

The benchmarks were separated into the following:
`DBRead`, `DBWrite`, `DBSeek`, `DBOverwrite`, `DBPut`, and `DBGet`.

The actual benchmarking was performed with the following command:

```
# only the output file names would differ for old goleveldb
go test -run=XXX -test.timeout=25m -benchmem -bench=BenchmarkDBRead -count=10 >       new-dbread.txt
go test -run=XXX -test.timeout=10m -benchmem -bench=BenchmarkDBWrite -count=10 >      new-dbwrite.txt
go test -run=XXX -test.timeout=10m -benchmem -bench=BenchmarkDBSeek -count=10 >       new-dbseek.txt
go test -run=XXX -test.timeout=10m -benchmem -bench=BenchmarkDBOverwrite -count=10 >  new-dboverwrite.txt
go test -run=XXX -test.timeout=10m -benchmem -bench=BenchmarkDBPut -count=10 >        new-dbput.txt
go test -run=XXX -test.timeout=10m -benchmem -bench=BenchmarkDBGet -count=10 >        new-dbget.txt
```

In some there was a lot of variation so the results might not mean much for those specific benchmarks.

## Biggest improvements

While most of the benchmarks showed no real difference, the biggest wins were from the following:

- alloc/op in DBRead
```
name                   old alloc/op   new alloc/op   delta
DBRead-12                 17.0B ± 0%     17.0B ± 0%     ~     (all equal)
DBReadGC-12               17.0B ± 0%     17.0B ± 0%     ~     (all equal)
DBReadUncompressed-12     20.0B ± 0%     16.0B ± 0%  -20.00%  (p=0.000 n=10+10)
DBReadTable-12            17.0B ± 0%     17.0B ± 0%     ~     (all equal)
DBReadReverse-12          66.0B ± 0%     66.0B ± 0%     ~     (all equal)
DBReadReverseTable-12     66.0B ± 0%     67.0B ± 0%   +1.52%  (p=0.000 n=10+9)
DBReadConcurrent-12       24.8B ±57%      9.4B ±17%  -62.10%  (p=0.000 n=10+10)
DBReadConcurrent2-12      49.1B ±36%     31.7B ± 4%  -35.51%  (p=0.000 n=10+9)
```

- time/op and speed in DBWrite

```
name                         old time/op    new time/op    delta
DBWrite-12                     2.05µs ± 1%    2.01µs ± 0%    -1.80%  (p=0.000 n=10+9)
DBWriteBatch-12                 535ns ± 2%     589ns ±19%      ~     (p=0.353 n=10+10)
DBWriteUncompressed-12         2.04µs ± 1%    2.01µs ± 1%    -1.48%  (p=0.000 n=10+10)
DBWriteBatchUncompressed-12    1.16µs ±35%    0.53µs ± 2%   -54.80%  (p=0.000 n=10+10)
DBWriteRandom-12               2.51µs ± 1%    2.49µs ± 2%      ~     (p=0.247 n=10+10)
DBWriteRandomSync-12            376µs ± 4%   1617µs ±204%      ~     (p=0.089 n=10+10)

name                         old speed      new speed      delta
DBWrite-12                   56.6MB/s ± 1%  57.7MB/s ± 0%    +1.84%  (p=0.000 n=10+9)
DBWriteBatch-12               217MB/s ± 2%   200MB/s ±17%      ~     (p=0.353 n=10+10)
DBWriteUncompressed-12       56.7MB/s ± 1%  57.6MB/s ± 1%    +1.50%  (p=0.000 n=10+10)
DBWriteBatchUncompressed-12   104MB/s ±48%   221MB/s ± 2%  +111.50%  (p=0.000 n=10+10)
DBWriteRandom-12             46.3MB/s ± 1%  46.5MB/s ± 2%      ~     (p=0.271 n=10+10)
DBWriteRandomSync-12          308kB/s ± 4%   221kB/s ±91%      ~     (p=0.121 n=10+10)
```

- time/op and speed in DBOverwrite

```
name                  old time/op    new time/op    delta
DBOverwrite-12          2.54µs ±25%    2.16µs ± 1%  -14.96%  (p=0.000 n=10+9)
DBOverwriteRandom-12    3.63µs ±26%    2.69µs ± 2%  -25.88%  (p=0.009 n=10+10)

name                  old speed      new speed      delta
DBOverwrite-12        46.8MB/s ±22%  53.7MB/s ± 1%  +14.64%  (p=0.000 n=10+9)
DBOverwriteRandom-12  33.1MB/s ±31%  43.1MB/s ± 2%  +30.03%  (p=0.009 n=10+10)
```

## Some extra memory allocation during the benchmarks

There were more memory being allocated for some tests. These are:

- DBOverwrite (do note that the speed and time/op was better)

```
name                  old alloc/op   new alloc/op   delta
DBOverwrite-12            102B ± 6%      135B ± 4%  +32.58%  (p=0.000 n=10+10)
DBOverwriteRandom-12      119B ± 3%      160B ± 6%  +35.30%  (p=0.000 n=9+10)
```

- DBWriteRandom (no difference in speed and time/op)

```
DBWriteRandom-12                 142B ± 2%      165B ± 3%   +16.20%  (p=0.000 n=10+9)
```

- DBGetRandom (speed and time/op was better)

```
DBGetRandom-12      16.0 ± 0%      18.0 ± 0%  +12.50%  (p=0.000 n=10+10)
```

## Full Benchstat results
```
name                   old time/op    new time/op    delta
DBRead-12                 236ns ± 1%     239ns ± 1%   +1.50%  (p=0.000 n=9+10)
DBReadGC-12               251ns ±10%     255ns ± 1%     ~     (p=0.382 n=10+6)
DBReadUncompressed-12     221ns ± 1%     223ns ± 1%   +1.04%  (p=0.000 n=9+8)
DBReadTable-12            222ns ±14%     227ns ± 1%     ~     (p=0.059 n=9+8)
DBReadReverse-12          339ns ± 2%     331ns ± 1%   -2.44%  (p=0.000 n=9+10)
DBReadReverseTable-12     335ns ± 1%     340ns ± 6%     ~     (p=0.483 n=9+10)
DBReadConcurrent-12      50.7ns ±12%    54.3ns ±28%     ~     (p=0.897 n=8+10)
DBReadConcurrent2-12     61.9ns ±22%    62.5ns ±21%     ~     (p=0.912 n=10+10)

name                   old speed      new speed      delta
DBRead-12               492MB/s ± 1%   485MB/s ± 1%   -1.48%  (p=0.000 n=9+10)
DBReadGC-12             464MB/s ± 9%   455MB/s ± 1%     ~     (p=0.428 n=10+6)
DBReadUncompressed-12   524MB/s ± 1%   519MB/s ± 1%   -1.04%  (p=0.000 n=9+8)
DBReadTable-12          524MB/s ±13%   511MB/s ± 1%     ~     (p=0.059 n=9+8)
DBReadReverse-12        342MB/s ± 2%   351MB/s ± 1%   +2.49%  (p=0.000 n=9+10)
DBReadReverseTable-12   346MB/s ± 1%   342MB/s ± 5%     ~     (p=0.483 n=9+10)
DBReadConcurrent-12    2.23GB/s ±25%  2.19GB/s ±24%     ~     (p=0.905 n=9+10)
DBReadConcurrent2-12   1.91GB/s ±20%  1.89GB/s ±19%     ~     (p=0.912 n=10+10)

name                   old alloc/op   new alloc/op   delta
DBRead-12                 17.0B ± 0%     17.0B ± 0%     ~     (all equal)
DBReadGC-12               17.0B ± 0%     17.0B ± 0%     ~     (all equal)
DBReadUncompressed-12     20.0B ± 0%     16.0B ± 0%  -20.00%  (p=0.000 n=10+10)
DBReadTable-12            17.0B ± 0%     17.0B ± 0%     ~     (all equal)
DBReadReverse-12          66.0B ± 0%     66.0B ± 0%     ~     (all equal)
DBReadReverseTable-12     66.0B ± 0%     67.0B ± 0%   +1.52%  (p=0.000 n=10+9)
DBReadConcurrent-12       24.8B ±57%      9.4B ±17%  -62.10%  (p=0.000 n=10+10)
DBReadConcurrent2-12      49.1B ±36%     31.7B ± 4%  -35.51%  (p=0.000 n=10+9)

name                   old allocs/op  new allocs/op  delta
DBRead-12                  0.00           0.00          ~     (all equal)
DBReadGC-12                0.00           0.00          ~     (all equal)
DBReadUncompressed-12      0.00           0.00          ~     (all equal)
DBReadTable-12             0.00           0.00          ~     (all equal)
DBReadReverse-12           0.00           0.00          ~     (all equal)
DBReadReverseTable-12      0.00           0.00          ~     (all equal)
DBReadConcurrent-12        0.00           0.00          ~     (all equal)
DBReadConcurrent2-12       0.00           0.00          ~     (all equal)
---------------------------------------------------------------
name                         old time/op    new time/op    delta
DBWrite-12                     2.05µs ± 1%    2.01µs ± 0%    -1.80%  (p=0.000 n=10+9)
DBWriteBatch-12                 535ns ± 2%     589ns ±19%      ~     (p=0.353 n=10+10)
DBWriteUncompressed-12         2.04µs ± 1%    2.01µs ± 1%    -1.48%  (p=0.000 n=10+10)
DBWriteBatchUncompressed-12    1.16µs ±35%    0.53µs ± 2%   -54.80%  (p=0.000 n=10+10)
DBWriteRandom-12               2.51µs ± 1%    2.49µs ± 2%      ~     (p=0.247 n=10+10)
DBWriteRandomSync-12            376µs ± 4%   1617µs ±204%      ~     (p=0.089 n=10+10)

name                         old speed      new speed      delta
DBWrite-12                   56.6MB/s ± 1%  57.7MB/s ± 0%    +1.84%  (p=0.000 n=10+9)
DBWriteBatch-12               217MB/s ± 2%   200MB/s ±17%      ~     (p=0.353 n=10+10)
DBWriteUncompressed-12       56.7MB/s ± 1%  57.6MB/s ± 1%    +1.50%  (p=0.000 n=10+10)
DBWriteBatchUncompressed-12   104MB/s ±48%   221MB/s ± 2%  +111.50%  (p=0.000 n=10+10)
DBWriteRandom-12             46.3MB/s ± 1%  46.5MB/s ± 2%      ~     (p=0.271 n=10+10)
DBWriteRandomSync-12          308kB/s ± 4%   221kB/s ±91%      ~     (p=0.121 n=10+10)

name                         old alloc/op   new alloc/op   delta
DBWrite-12                       110B ± 1%      110B ± 0%      ~     (p=0.103 n=10+7)
DBWriteBatch-12                 18.0B ± 0%     19.5B ±13%      ~     (p=0.108 n=9+10)
DBWriteUncompressed-12           109B ± 1%      109B ± 1%    -0.64%  (p=0.044 n=10+10)
DBWriteBatchUncompressed-12     30.0B ±43%     17.0B ± 0%   -43.33%  (p=0.000 n=10+9)
DBWriteRandom-12                 142B ± 2%      165B ± 3%   +16.20%  (p=0.000 n=10+9)
DBWriteRandomSync-12             259B ± 9%      258B ±11%      ~     (p=0.948 n=10+8)

name                         old allocs/op  new allocs/op  delta
DBWrite-12                       3.00 ± 0%      3.00 ± 0%      ~     (all equal)
DBWriteBatch-12                  0.00           0.00           ~     (all equal)
DBWriteUncompressed-12           3.00 ± 0%      3.00 ± 0%      ~     (all equal)
DBWriteBatchUncompressed-12      0.00           0.00           ~     (all equal)
DBWriteRandom-12                 3.00 ± 0%      3.00 ± 0%      ~     (all equal)
DBWriteRandomSync-12             3.00 ± 0%      3.00 ± 0%      ~     (all equal)
---------------------------------------------------------------
name             old time/op    new time/op    delta
DBSeek-12          6.17µs ± 1%    6.13µs ± 0%  -0.69%  (p=0.000 n=10+10)
DBSeekRandom-12    8.55µs ± 1%    8.49µs ± 0%  -0.67%  (p=0.001 n=10+10)

name             old alloc/op   new alloc/op   delta
DBSeek-12          1.51kB ± 0%    1.51kB ± 0%    ~     (all equal)
DBSeekRandom-12    1.75kB ± 0%    1.75kB ± 0%    ~     (all equal)

name             old allocs/op  new allocs/op  delta
DBSeek-12            18.0 ± 0%      18.0 ± 0%    ~     (all equal)
DBSeekRandom-12      23.0 ± 0%      23.0 ± 0%    ~     (all equal)
---------------------------------------------------------------
name                  old time/op    new time/op    delta
DBOverwrite-12          2.54µs ±25%    2.16µs ± 1%  -14.96%  (p=0.000 n=10+9)
DBOverwriteRandom-12    3.63µs ±26%    2.69µs ± 2%  -25.88%  (p=0.009 n=10+10)

name                  old speed      new speed      delta
DBOverwrite-12        46.8MB/s ±22%  53.7MB/s ± 1%  +14.64%  (p=0.000 n=10+9)
DBOverwriteRandom-12  33.1MB/s ±31%  43.1MB/s ± 2%  +30.03%  (p=0.009 n=10+10)

name                  old alloc/op   new alloc/op   delta
DBOverwrite-12            102B ± 6%      135B ± 4%  +32.58%  (p=0.000 n=10+10)
DBOverwriteRandom-12      119B ± 3%      160B ± 6%  +35.30%  (p=0.000 n=9+10)

name                  old allocs/op  new allocs/op  delta
DBOverwrite-12            3.00 ± 0%      3.00 ± 0%     ~     (all equal)
DBOverwriteRandom-12      3.00 ± 0%      3.00 ± 0%     ~     (all equal)
---------------------------------------------------------------
name      old time/op    new time/op    delta
DBPut-12    2.10µs ± 2%    2.07µs ± 1%  -1.56%  (p=0.003 n=10+10)

name      old speed      new speed      delta
DBPut-12  55.2MB/s ± 2%  56.1MB/s ± 1%  +1.59%  (p=0.003 n=10+10)

name      old alloc/op   new alloc/op   delta
DBPut-12      112B ± 1%      111B ± 1%  -0.89%  (p=0.005 n=10+10)

name      old allocs/op  new allocs/op  delta
DBPut-12      3.00 ± 0%      3.00 ± 0%    ~     (all equal)
---------------------------------------------------------------
name            old time/op    new time/op    delta
DBGet-12          2.43µs ± 1%    2.35µs ± 1%   -3.12%  (p=0.000 n=9+8)
DBGetRandom-12    4.97µs ± 0%    4.86µs ± 1%   -2.14%  (p=0.000 n=8+10)

name            old alloc/op   new alloc/op   delta
DBGet-12            788B ± 0%      788B ± 0%     ~     (p=0.889 n=10+8)
DBGetRandom-12    1.00kB ± 0%    1.05kB ± 0%   +4.29%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
DBGet-12            12.0 ± 0%      12.0 ± 0%     ~     (all equal)
DBGetRandom-12      16.0 ± 0%      18.0 ± 0%  +12.50%  (p=0.000 n=10+10)
```

For the use case of the project I'm working on, this PR was an immense improvement. From the benchstat results, we can assume that it would be an immense improvement for other projects as well. 