### PR TITLE
small optimize to memdb.Delete

### DIFF
--- a/leveldb/memdb/memdb.go
+++ b/leveldb/memdb/memdb.go
@@ -330,7 +330,7 @@ func (p *DB) Delete(key []byte) error {
 	h := p.nodeData[node+nHeight]
 	for i, n := range p.prevNode[:h] {
 		m := n + nNext + i
-		p.nodeData[m] = p.nodeData[p.nodeData[m]+nNext+i]
+		p.nodeData[m] = p.nodeData[node+nNext+i]
 	}
 
 	p.kvSize -= p.nodeData[node+nKey] + p.nodeData[node+nVal]


### PR DESCRIPTION
the "next" of the previous node is current node, so we can just use  node to replace p.nodeData[m];
