### PR TITLE
leveldb: add option SkipL0SeeksCompaction

### DIFF
--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -284,6 +284,12 @@ type Options struct {
 	// The default is false.
 	DisableSeeksCompaction bool
 
+	// SkipL0SeeksCompaction allows skipping L0 'seeks triggered compaction'.
+	// If enable, 'level seeks' can still be minimized without too many small compactions.
+	//
+	// The default value is false.
+	SkipL0SeeksCompaction bool
+
 	// ErrorIfExist defines whether an error should returned if the DB already
 	// exist.
 	//
@@ -542,6 +548,13 @@ func (o *Options) GetDisableSeeksCompaction() bool {
 		return false
 	}
 	return o.DisableSeeksCompaction
+}
+
+func (o *Options) GetMinSampleSeeksLevel() int {
+	if o == nil || !o.SkipL0SeeksCompaction {
+		return 0
+	}
+	return 1
 }
 
 func (o *Options) GetErrorIfExist() bool {

--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -162,7 +162,7 @@ func (v *version) get(aux tFiles, ikey internalKey, ro *opt.ReadOptions, noValue
 	// Since entries never hop across level, finding key/value
 	// in smaller level make later levels irrelevant.
 	v.walkOverlapping(aux, ikey, func(level int, t *tFile) bool {
-		if sampleSeeks && level >= 0 && !tseek {
+		if sampleSeeks && level >= v.s.o.GetMinSampleSeeksLevel() && !tseek {
 			if tset == nil {
 				tset = &tSet{level, t}
 			} else {
@@ -245,7 +245,9 @@ func (v *version) sampleSeek(ikey internalKey) (tcomp bool) {
 
 	v.walkOverlapping(nil, ikey, func(level int, t *tFile) bool {
 		if tset == nil {
-			tset = &tSet{level, t}
+			if level >= v.s.o.GetMinSampleSeeksLevel() {
+				tset = &tSet{level, t}
+			}
 			return true
 		}
 		if tset.table.consumeSeek() <= 0 {


### PR DESCRIPTION
If the option `DisableSeeksCompaction` turned on, the read performance is heavily downgraded for a large dataset, caused by too many level seeks. The new option `SkipL0SeeksCompaction` is to only skip seeks compactions from level-0, so level seeks optimization still works on higher levels. In my case, most of seeks compactions are from level-0. By turning on the new option, the count of seeks compactions is significantly decreased.