### PR TITLE
leveldb/memdb: avoid repeated comparisons

### DIFF
--- a/leveldb/memdb/memdb.go
+++ b/leveldb/memdb/memdb.go
@@ -211,10 +211,11 @@ func (p *DB) randHeight() (h int) {
 func (p *DB) findGE(key []byte, prev bool) (int, bool) {
 	node := 0
 	h := p.maxHeight - 1
+	visited := 0
 	for {
 		next := p.nodeData[node+nNext+h]
 		cmp := 1
-		if next != 0 {
+		if next != 0 && next != visited {
 			o := p.nodeData[next]
 			cmp = p.cmp.Compare(p.kvData[o:o+p.nodeData[next+nKey]], key)
 		}
@@ -222,6 +223,11 @@ func (p *DB) findGE(key []byte, prev bool) (int, bool) {
 			// Keep searching in this list
 			node = next
 		} else {
+			if next != 0 {
+				// If we go down further, we can skip this element if we
+				// encounter it on a lower level.
+				visited = next
+			}
 			if prev {
 				p.prevNode[h] = node
 			} else if cmp == 0 {


### PR DESCRIPTION
When the memory database does a search through the skiplist, it descends one level whenver it either finds that the list is ended, or that the comparison fails (we've passed the item). 
In the latter case, we descend a level, and a non-insignificant amount of times, the search on _that_ level will also end on the same exact item -- since if the item was at the upper level, it's guaranteed to be present on the lower level too. 

By adding one local int, to keep track of, basically, "an item we found on the upper level, which is known to be past the item we're searching for", we can avoid doing that comparison again. 

Using this fix, plus a global comparison counter, I made these charts. It imports `30M` items, each with a `32` byte key and a `1` byte value. At 100 points during this import, I dump out the average comparison ops performed in that range. 


This is `master`
![memdb-12-4-31457280](https://user-images.githubusercontent.com/142290/145232469-288838c7-c349-443c-a20f-201b3a66bab5.png)

It executed it in `175.91 seconds`, doing `1416736538` comparison calls in total. 

This is this PR: 

![memdb-12-4-31457280 pr](https://user-images.githubusercontent.com/142290/145232519-46149dc0-3b94-4e85-ae55-6fb74f563a21.png)

It executed it in ` 171.51 seconds`, doing `1333783947` comparison calls in total. 
