### PR TITLE
util: Switch shortenb/sshortenb to int64

### DIFF
--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -272,7 +272,7 @@ func (db *DB) memCompaction() {
 	}
 	defer mdb.decref()
 
-	db.logf("memdb@flush N·%d S·%s", mdb.Len(), shortenb(mdb.Size()))
+	db.logf("memdb@flush N·%d S·%s", mdb.Len(), shortenb(int64(mdb.Size())))
 
 	// Don't compact empty memdb.
 	if mdb.Len() == 0 {
@@ -410,7 +410,7 @@ func (b *tableCompactionBuilder) flush() error {
 	}
 	b.rec.addTableFile(b.c.sourceLevel+1, t)
 	b.stat1.write += t.size
-	b.s.logf("table@build created L%d@%d N·%d S·%s %q:%q", b.c.sourceLevel+1, t.fd.Num, b.tw.tw.EntriesLen(), shortenb(int(t.size)), t.imin, t.imax)
+	b.s.logf("table@build created L%d@%d N·%d S·%s %q:%q", b.c.sourceLevel+1, t.fd.Num, b.tw.tw.EntriesLen(), shortenb(t.size), t.imin, t.imax)
 	b.tw = nil
 	return nil
 }
@@ -563,7 +563,7 @@ func (db *DB) tableCompaction(c *compaction, noTrivial bool) {
 			rec.delTable(c.sourceLevel+i, t.fd.Num)
 		}
 	}
-	sourceSize := int(stats[0].read + stats[1].read)
+	sourceSize := stats[0].read + stats[1].read
 	minSeq := db.minSeq()
 	db.logf("table@compaction L%d·%d -> L%d·%d S·%s Q·%d", c.sourceLevel, len(c.levels[0]), c.sourceLevel+1, len(c.levels[1]), shortenb(sourceSize), minSeq)
 
@@ -584,7 +584,7 @@ func (db *DB) tableCompaction(c *compaction, noTrivial bool) {
 	db.compactionCommit("table", rec)
 	stats[1].stopTimer()
 
-	resultSize := int(stats[1].write)
+	resultSize := stats[1].write
 	db.logf("table@compaction committed F%s S%s Ke·%d D·%d T·%v", sint(len(rec.addedTables)-len(rec.deletedTables)), sshortenb(resultSize-sourceSize), b.kerrCnt, b.dropCnt, stats[1].duration)
 
 	// Save compaction stats

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -2736,7 +2736,7 @@ func testDB_IterTriggeredCompaction(t *testing.T, limitDiv int) {
 		initialSize1 = h.sizeOf(limitKey, maxKey)
 	)
 
-	t.Logf("initial size %s [rest %s]", shortenb(int(initialSize0)), shortenb(int(initialSize1)))
+	t.Logf("initial size %s [rest %s]", shortenb(initialSize0), shortenb(initialSize1))
 
 	for r := 0; true; r++ {
 		if r >= mIter {
@@ -2758,7 +2758,7 @@ func testDB_IterTriggeredCompaction(t *testing.T, limitDiv int) {
 		// Check size.
 		size0 := h.sizeOf(startKey, limitKey)
 		size1 := h.sizeOf(limitKey, maxKey)
-		t.Logf("#%03d size %s [rest %s]", r, shortenb(int(size0)), shortenb(int(size1)))
+		t.Logf("#%03d size %s [rest %s]", r, shortenb(size0), shortenb(size1))
 		if size0 < initialSize0/10 {
 			break
 		}

--- a/leveldb/db_transaction.go
+++ b/leveldb/db_transaction.go
@@ -110,7 +110,7 @@ func (tr *Transaction) flush() error {
 		tr.tables = append(tr.tables, t)
 		tr.rec.addTableFile(0, t)
 		tr.stats.write += t.size
-		tr.db.logf("transaction@flush created L0@%d N·%d S·%s %q:%q", t.fd.Num, n, shortenb(int(t.size)), t.imin, t.imax)
+		tr.db.logf("transaction@flush created L0@%d N·%d S·%s %q:%q", t.fd.Num, n, shortenb(t.size), t.imin, t.imax)
 	}
 	return nil
 }

--- a/leveldb/session_compaction.go
+++ b/leveldb/session_compaction.go
@@ -48,7 +48,7 @@ func (s *session) flushMemdb(rec *sessionRecord, mdb *memdb.DB, maxLevel int) (i
 	flushLevel := s.pickMemdbLevel(t.imin.ukey(), t.imax.ukey(), maxLevel)
 	rec.addTableFile(flushLevel, t)
 
-	s.logf("memdb@flush created L%d@%d N·%d S·%s %q:%q", flushLevel, t.fd.Num, n, shortenb(int(t.size)), t.imin, t.imax)
+	s.logf("memdb@flush created L%d@%d N·%d S·%s %q:%q", flushLevel, t.fd.Num, n, shortenb(t.size), t.imin, t.imax)
 	return flushLevel, nil
 }
 
@@ -226,8 +226,8 @@ func (c *compaction) expand() {
 			exp1 := vt1.getOverlaps(nil, c.s.icmp, xmin.ukey(), xmax.ukey(), false)
 			if len(exp1) == len(t1) {
 				c.s.logf("table@compaction expanding L%d+L%d (F·%d S·%s)+(F·%d S·%s) -> (F·%d S·%s)+(F·%d S·%s)",
-					c.sourceLevel, c.sourceLevel+1, len(t0), shortenb(int(t0.size())), len(t1), shortenb(int(t1.size())),
-					len(exp0), shortenb(int(exp0.size())), len(exp1), shortenb(int(exp1.size())))
+					c.sourceLevel, c.sourceLevel+1, len(t0), shortenb(t0.size()), len(t1), shortenb(t1.size()),
+					len(exp0), shortenb(exp0.size()), len(exp1), shortenb(exp1.size()))
 				imin, imax = xmin, xmax
 				t0, t1 = exp0, exp1
 				amin, amax = append(t0, t1...).getRange(c.s.icmp)

--- a/leveldb/session_util.go
+++ b/leveldb/session_util.go
@@ -24,7 +24,7 @@ type dropper struct {
 
 func (d dropper) Drop(err error) {
 	if e, ok := err.(*journal.ErrCorrupted); ok {
-		d.s.logf("journal@drop %s-%d S·%s %q", d.fd.Type, d.fd.Num, shortenb(e.Size), e.Reason)
+		d.s.logf("journal@drop %s-%d S·%s %q", d.fd.Type, d.fd.Num, shortenb(int64(e.Size)), e.Reason)
 	} else {
 		d.s.logf("journal@drop %s-%d %q", d.fd.Type, d.fd.Num, err)
 	}

--- a/leveldb/util.go
+++ b/leveldb/util.go
@@ -22,7 +22,7 @@ func shorten(str string) string {
 
 var bunits = [...]string{"", "Ki", "Mi", "Gi", "Ti"}
 
-func shortenb(bytes int) string {
+func shortenb(bytes int64) string {
 	i := 0
 	for ; bytes > 1024 && i < 4; i++ {
 		bytes /= 1024
@@ -30,7 +30,7 @@ func shortenb(bytes int) string {
 	return fmt.Sprintf("%d%sB", bytes, bunits[i])
 }
 
-func sshortenb(bytes int) string {
+func sshortenb(bytes int64) string {
 	if bytes == 0 {
 		return "~"
 	}

--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -388,7 +388,7 @@ func (v *version) computeCompaction() {
 		}
 
 		statFiles[level] = len(tables)
-		statSizes[level] = shortenb(int(size))
+		statSizes[level] = shortenb(size)
 		statScore[level] = fmt.Sprintf("%.2f", score)
 		statTotSize += size
 	}
@@ -396,7 +396,7 @@ func (v *version) computeCompaction() {
 	v.cLevel = bestLevel
 	v.cScore = bestScore
 
-	v.s.logf("version@stat F·%v S·%s%v Sc·%v", statFiles, shortenb(int(statTotSize)), statSizes, statScore)
+	v.s.logf("version@stat F·%v S·%s%v Sc·%v", statFiles, shortenb(statTotSize), statSizes, statScore)
 }
 
 func (v *version) needCompaction() bool {


### PR DESCRIPTION
Most calls already happen with `int64` instances, so this change reduces
one type conversion. On 32-bit arch, converting int64 -> int is lossy
and results in incorrect values being print for levels > 2GiB.