### PR TITLE
leveldb: introduce MakeBatchWithConfig API

### DIFF
--- a/leveldb/batch_test.go
+++ b/leveldb/batch_test.go
@@ -9,6 +9,7 @@ package leveldb
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"testing"
 	"testing/quick"
 
@@ -144,4 +145,34 @@ func TestBatch(t *testing.T) {
 		t.Error(err)
 	}
 	t.Logf("length=%d internalLen=%d", len(kvs), internalLen)
+}
+
+func BenchmarkDefaultBatchWrite(b *testing.B) {
+	benchmarkBatchWrite(b, nil)
+}
+
+func BenchmarkFastAllocationBatchWrite(b *testing.B) {
+	benchmarkBatchWrite(b, &BatchConfig{
+		SlowAllocation: 10 * batchGrowRec,
+	})
+}
+
+func benchmarkBatchWrite(b *testing.B, config *BatchConfig) {
+	var (
+		keys [][]byte
+		vals [][]byte
+		r    = rand.New(rand.NewSource(1337))
+	)
+	for i := 0; i < 50000; i++ {
+		keys = append(keys, randomString(r, 32))
+		vals = append(vals, randomString(r, 100))
+	}
+	b.ResetTimer()
+	for round := 0; round < b.N; round += 1 {
+		batch := MakeBatchWithConfig(config)
+		for i := 0; i < len(keys); i++ {
+			batch.Put(keys[i], vals[i])
+		}
+	}
+	b.ReportAllocs()
 }

--- a/leveldb/opt/options_darwin.go
+++ b/leveldb/opt/options_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package opt

--- a/leveldb/opt/options_default.go
+++ b/leveldb/opt/options_default.go
@@ -1,3 +1,4 @@
+//go:build !darwin
 // +build !darwin
 
 package opt

--- a/leveldb/storage/file_storage_nacl.go
+++ b/leveldb/storage/file_storage_nacl.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+//go:build nacl
 // +build nacl
 
 package storage

--- a/leveldb/storage/file_storage_solaris.go
+++ b/leveldb/storage/file_storage_solaris.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+//go:build solaris
 // +build solaris
 
 package storage

--- a/leveldb/storage/file_storage_unix.go
+++ b/leveldb/storage/file_storage_unix.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
 // +build darwin dragonfly freebsd linux netbsd openbsd
 
 package storage

--- a/leveldb/util/buffer_pool.go
+++ b/leveldb/util/buffer_pool.go
@@ -110,22 +110,22 @@ func NewBufferPool(baseline int) *BufferPool {
 	bufPool := &BufferPool{
 		baseline: [...]int{baseline / 4, baseline / 2, baseline, baseline * 2, baseline * 4},
 		pool: [6]sync.Pool{
-			sync.Pool{
+			{
 				New: func() interface{} { return new([]byte) },
 			},
-			sync.Pool{
+			{
 				New: func() interface{} { return new([]byte) },
 			},
-			sync.Pool{
+			{
 				New: func() interface{} { return new([]byte) },
 			},
-			sync.Pool{
+			{
 				New: func() interface{} { return new([]byte) },
 			},
-			sync.Pool{
+			{
 				New: func() interface{} { return new([]byte) },
 			},
-			sync.Pool{
+			{
 				New: func() interface{} { return new([]byte) },
 			},
 		},


### PR DESCRIPTION
This PR introduces a new API `MakeBatchWithConfig` which accepts a config object when initialize the batch.

The batch object can be used in different scenarios, both for small write and large write. Recently we discover it's really inefficient when constructing a large batch. After some investigation, it turns out the memory allocation algorithm is inefficient in this case, in another word, the allocation step is too small which leads to countless allocation operations.

So this new API is added in terms of offering flexible configuration.

PS, this PR contains some format changes added by run `gofmt` 

## Benchmark

**Default settings**
```
BenchmarkDefaultBatchWrite-8         205           5156679 ns/op        73905957 B/op         54 allocs/op
```

**Customized setting**
```
BenchmarkFastAllocationBatchWrite-8          523           2374309 ns/op        28374806 B/op         43 allocs/op
```
