### PR TITLE
util: improve BufferPool, eliminate unexpected allocations

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -304,7 +304,7 @@ func recoverTable(s *session, o *opt.Options) error {
 		noSync = o.GetNoSync()
 
 		rec   = &sessionRecord{}
-		bpool = util.NewBufferPool(o.GetBlockSize() + 5)
+		bpool = util.NewBufferPool(o.GetBlockSize() * 2)
 	)
 	buildTable := func(iter iterator.Iterator) (tmpFd storage.FileDesc, size int64, err error) {
 		tmpFd = s.newTemp()
@@ -329,7 +329,7 @@ func recoverTable(s *session, o *opt.Options) error {
 		}()
 
 		// Copy entries.
-		tw := table.NewWriter(writer, o, nil, 0)
+		tw := table.NewWriter(writer, o, nil)
 		for iter.Next() {
 			key := iter.Key()
 			if validInternalKey(key) {

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -390,7 +390,7 @@ func (b *tableCompactionBuilder) appendKV(key, value []byte) error {
 
 		// Create new table.
 		var err error
-		b.tw, err = b.s.tops.create(b.tableSize)
+		b.tw, err = b.s.tops.create()
 		if err != nil {
 			return err
 		}

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -2611,7 +2611,7 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 		value      = bytes.Repeat([]byte{'0'}, 100)
 	)
 	for i := 0; i < 2; i++ {
-		tw, err := s.tops.create(0)
+		tw, err := s.tops.create()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -354,7 +354,7 @@ type tOps struct {
 }
 
 // Creates an empty table and returns table writer.
-func (t *tOps) create(tSize int) (*tWriter, error) {
+func (t *tOps) create() (*tWriter, error) {
 	fd := storage.FileDesc{Type: storage.TypeTable, Num: t.s.allocFileNum()}
 	fw, err := t.s.stor.Create(fd)
 	if err != nil {
@@ -364,13 +364,13 @@ func (t *tOps) create(tSize int) (*tWriter, error) {
 		t:  t,
 		fd: fd,
 		w:  fw,
-		tw: table.NewWriter(fw, t.s.o.Options, t.blockBuffer, tSize),
+		tw: table.NewWriter(fw, t.s.o.Options, t.blockBuffer),
 	}, nil
 }
 
 // Builds table from src iterator.
 func (t *tOps) createFrom(src iterator.Iterator) (f *tFile, n int, err error) {
-	w, err := t.create(0)
+	w, err := t.create()
 	if err != nil {
 		return
 	}
@@ -515,7 +515,7 @@ func newTableOps(s *session) *tOps {
 		blockCache = cache.NewCache(blockCacher)
 	}
 	if !s.o.GetDisableBufferPool() {
-		blockBuffer = util.NewBufferPool(s.o.GetBlockSize() + 5)
+		blockBuffer = util.NewBufferPool(s.o.GetBlockSize() * 2)
 	}
 	return &tOps{
 		s:            s,

--- a/leveldb/table/table_test.go
+++ b/leveldb/table/table_test.go
@@ -47,7 +47,7 @@ var _ = testutil.Defer(func() {
 			)
 
 			// Building the table.
-			tw := NewWriter(buf, o, nil, 0)
+			tw := NewWriter(buf, o, nil)
 			err := tw.Append([]byte("k01"), []byte("hello"))
 			Expect(err).ShouldNot(HaveOccurred())
 			err = tw.Append([]byte("k02"), []byte("hello2"))
@@ -98,7 +98,7 @@ var _ = testutil.Defer(func() {
 				buf := &bytes.Buffer{}
 
 				// Building the table.
-				tw := NewWriter(buf, o, nil, 0)
+				tw := NewWriter(buf, o, nil)
 				kv.Iterate(func(i int, key, value []byte) {
 					Expect(tw.Append(key, value)).ShouldNot(HaveOccurred())
 				})

--- a/leveldb/table/writer.go
+++ b/leveldb/table/writer.go
@@ -389,15 +389,8 @@ func (w *Writer) Close() error {
 // NewWriter creates a new initialized table writer for the file.
 //
 // Table writer is not safe for concurrent use.
-func NewWriter(f io.Writer, o *opt.Options, pool *util.BufferPool, size int) *Writer {
-	var bufBytes []byte
-	if pool == nil {
-		bufBytes = make([]byte, size)
-	} else {
-		bufBytes = pool.Get(size)
-	}
-	bufBytes = bufBytes[:0]
-
+func NewWriter(f io.Writer, o *opt.Options, pool *util.BufferPool) *Writer {
+	bufBytes := pool.Get(0)
 	w := &Writer{
 		writer:          f,
 		cmp:             o.GetComparer(),

--- a/leveldb/util/buffer_pool_test.go
+++ b/leveldb/util/buffer_pool_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2014, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package util
+
+import "testing"
+
+func BenchmarkBufferPool(b *testing.B) {
+	const n = 100
+	pool := NewBufferPool(n)
+
+	for i := 0; i < b.N; i++ {
+		buf := pool.Get(n)
+		pool.Put(buf)
+	}
+}

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -309,7 +309,7 @@ func main() {
 	flag.Parse()
 
 	if enableBufferPool {
-		bpool = util.NewBufferPool(opt.DefaultBlockSize + 128)
+		bpool = util.NewBufferPool(opt.DefaultBlockSize * 2)
 	}
 
 	log.Printf("Test DB stored at %q", dbPath)


### PR DESCRIPTION
Using sync.Pool to manage bare slices is not the proper way, since it'll bring unexpected allocations. This PR solves this problem with small tricks and makes BufferPool a bit faster.

benchmarks:

```bash
$ benchstat before.txt after.txt 
name          old time/op    new time/op    delta
BufferPool-8    55.9ns ± 0%    34.8ns ± 0%   -37.71%  (p=0.008 n=5+5)

name          old alloc/op   new alloc/op   delta
BufferPool-8     24.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
BufferPool-8      1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
```