### PR TITLE
leveldb: fix table file leaks when manifest is rotated

### DIFF
--- a/leveldb/session.go
+++ b/leveldb/session.go
@@ -223,9 +223,12 @@ func (s *session) commit(r *sessionRecord, trivial bool) (err error) {
 		}
 	}()
 
-	if s.manifest == nil || s.manifest.Size() >= s.o.GetMaxManifestFileSize() {
+	if s.manifest == nil {
 		// manifest journal writer not yet created, create one
 		err = s.newManifest(r, nv)
+	} else if s.manifest.Size() >= s.o.GetMaxManifestFileSize() {
+		// pass nil sessionRecord to avoid over-reference table file
+		err = s.newManifest(nil, nv)
 	} else {
 		err = s.flushManifest(r)
 	}


### PR DESCRIPTION
When switched to the master branch, the size of my project's result db is much larger than before. The size is shrunk when restarted and many logs `db@janitor removing table-xxx` printed. I found that it's caused by the recently merge PR #380. 
