### PR TITLE
leveldb: fix incorrect buf size for table Writer

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -304,7 +304,7 @@ func recoverTable(s *session, o *opt.Options) error {
 		noSync = o.GetNoSync()
 
 		rec   = &sessionRecord{}
-		bpool = util.NewBufferPool(o.GetBlockSize() + 5)
+		bpool = util.NewBufferPool(o.GetBlockSize())
 	)
 	buildTable := func(iter iterator.Iterator) (tmpFd storage.FileDesc, size int64, err error) {
 		tmpFd = s.newTemp()

--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -329,7 +329,7 @@ func recoverTable(s *session, o *opt.Options) error {
 		}()
 
 		// Copy entries.
-		tw := table.NewWriter(writer, o, nil, 0)
+		tw := table.NewWriter(writer, o, nil)
 		for iter.Next() {
 			key := iter.Key()
 			if validInternalKey(key) {

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -390,7 +390,7 @@ func (b *tableCompactionBuilder) appendKV(key, value []byte) error {
 
 		// Create new table.
 		var err error
-		b.tw, err = b.s.tops.create(b.tableSize)
+		b.tw, err = b.s.tops.create()
 		if err != nil {
 			return err
 		}

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -2611,7 +2611,7 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 		value      = bytes.Repeat([]byte{'0'}, 100)
 	)
 	for i := 0; i < 2; i++ {
-		tw, err := s.tops.create(0)
+		tw, err := s.tops.create()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -354,7 +354,7 @@ type tOps struct {
 }
 
 // Creates an empty table and returns table writer.
-func (t *tOps) create(tSize int) (*tWriter, error) {
+func (t *tOps) create() (*tWriter, error) {
 	fd := storage.FileDesc{Type: storage.TypeTable, Num: t.s.allocFileNum()}
 	fw, err := t.s.stor.Create(fd)
 	if err != nil {
@@ -364,13 +364,13 @@ func (t *tOps) create(tSize int) (*tWriter, error) {
 		t:  t,
 		fd: fd,
 		w:  fw,
-		tw: table.NewWriter(fw, t.s.o.Options, t.blockBuffer, tSize),
+		tw: table.NewWriter(fw, t.s.o.Options, t.blockBuffer),
 	}, nil
 }
 
 // Builds table from src iterator.
 func (t *tOps) createFrom(src iterator.Iterator) (f *tFile, n int, err error) {
-	w, err := t.create(0)
+	w, err := t.create()
 	if err != nil {
 		return
 	}

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -515,7 +515,7 @@ func newTableOps(s *session) *tOps {
 		blockCache = cache.NewCache(blockCacher)
 	}
 	if !s.o.GetDisableBufferPool() {
-		blockBuffer = util.NewBufferPool(s.o.GetBlockSize() + 5)
+		blockBuffer = util.NewBufferPool(s.o.GetBlockSize())
 	}
 	return &tOps{
 		s:            s,

--- a/leveldb/table/table_test.go
+++ b/leveldb/table/table_test.go
@@ -47,7 +47,7 @@ var _ = testutil.Defer(func() {
 			)
 
 			// Building the table.
-			tw := NewWriter(buf, o, nil, 0)
+			tw := NewWriter(buf, o, nil)
 			err := tw.Append([]byte("k01"), []byte("hello"))
 			Expect(err).ShouldNot(HaveOccurred())
 			err = tw.Append([]byte("k02"), []byte("hello2"))
@@ -98,7 +98,7 @@ var _ = testutil.Defer(func() {
 				buf := &bytes.Buffer{}
 
 				// Building the table.
-				tw := NewWriter(buf, o, nil, 0)
+				tw := NewWriter(buf, o, nil)
 				kv.Iterate(func(i int, key, value []byte) {
 					Expect(tw.Append(key, value)).ShouldNot(HaveOccurred())
 				})

--- a/leveldb/table/writer.go
+++ b/leveldb/table/writer.go
@@ -393,9 +393,9 @@ func NewWriter(f io.Writer, o *opt.Options, pool *util.BufferPool) *Writer {
 	blockSize := o.GetBlockSize()
 	var bufBytes []byte
 	if pool == nil {
-		bufBytes = make([]byte, blockSize)
+		bufBytes = make([]byte, blockSize+blockTrailerLen)
 	} else {
-		bufBytes = pool.Get(blockSize)
+		bufBytes = pool.Get(blockSize + blockTrailerLen)
 	}
 	bufBytes = bufBytes[:0]
 

--- a/leveldb/table/writer.go
+++ b/leveldb/table/writer.go
@@ -389,24 +389,24 @@ func (w *Writer) Close() error {
 // NewWriter creates a new initialized table writer for the file.
 //
 // Table writer is not safe for concurrent use.
-func NewWriter(f io.Writer, o *opt.Options, pool *util.BufferPool, size int) *Writer {
+func NewWriter(f io.Writer, o *opt.Options, pool *util.BufferPool) *Writer {
+	blockSize := o.GetBlockSize()
 	var bufBytes []byte
 	if pool == nil {
-		bufBytes = make([]byte, size)
+		bufBytes = make([]byte, blockSize)
 	} else {
-		bufBytes = pool.Get(size)
+		bufBytes = pool.Get(blockSize)
 	}
 	bufBytes = bufBytes[:0]
 
 	w := &Writer{
-		writer:          f,
-		cmp:             o.GetComparer(),
-		filter:          o.GetFilter(),
-		compression:     o.GetCompression(),
-		blockSize:       o.GetBlockSize(),
-		comparerScratch: make([]byte, 0),
-		bpool:           pool,
-		dataBlock:       blockWriter{buf: *util.NewBuffer(bufBytes)},
+		writer:      f,
+		cmp:         o.GetComparer(),
+		filter:      o.GetFilter(),
+		compression: o.GetCompression(),
+		blockSize:   blockSize,
+		bpool:       pool,
+		dataBlock:   blockWriter{buf: *util.NewBuffer(bufBytes)},
 	}
 	// data block
 	w.dataBlock.restartInterval = o.GetBlockRestartInterval()

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -309,7 +309,7 @@ func main() {
 	flag.Parse()
 
 	if enableBufferPool {
-		bpool = util.NewBufferPool(opt.DefaultBlockSize + 128)
+		bpool = util.NewBufferPool(opt.DefaultBlockSize)
 	}
 
 	log.Printf("Test DB stored at %q", dbPath)


### PR DESCRIPTION
The buffer size should be block size instead of table size.