### PR TITLE
fix(db_compaction): fix backoffMul wrongly use Duration type

### DIFF
--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -164,7 +164,7 @@ func (db *DB) compactionTransact(name string, t compactionTransactInterface) {
 	const (
 		backoffMin = 1 * time.Second
 		backoffMax = 8 * time.Second
-		backoffMul = 2 * time.Second
+		backoffMul = 2
 	)
 	var (
 		backoff  = backoffMin


### PR DESCRIPTION
obviously `backoffMul `should be an integer not a time.Duration
https://github.com/syndtr/goleveldb/blob/64ee5596c38af10edb6d93e1327b3ed1739747c7/leveldb/db_compaction.go#L222