### PR TITLE
memdb: merge nodeData and kvData to speedup access

### DIFF
--- a/leveldb/memdb/memdb_test.go
+++ b/leveldb/memdb/memdb_test.go
@@ -19,10 +19,9 @@ import (
 func (p *DB) TestFindLT(key []byte) (rkey, value []byte, err error) {
 	p.mu.RLock()
 	if node := p.findLT(key); node != 0 {
-		n := p.nodeData[node]
-		m := n + p.nodeData[node+nKey]
-		rkey = p.kvData[n:m]
-		value = p.kvData[m : m+p.nodeData[node+nVal]]
+		kv := p.kvSlice(p.nodeData[node])
+		rkey = kv[:p.nodeData[node+nKey]]
+		value = kv[p.nodeData[node+nKey]:][:p.nodeData[node+nVal]]
 	} else {
 		err = ErrNotFound
 	}
@@ -33,10 +32,9 @@ func (p *DB) TestFindLT(key []byte) (rkey, value []byte, err error) {
 func (p *DB) TestFindLast() (rkey, value []byte, err error) {
 	p.mu.RLock()
 	if node := p.findLast(); node != 0 {
-		n := p.nodeData[node]
-		m := n + p.nodeData[node+nKey]
-		rkey = p.kvData[n:m]
-		value = p.kvData[m : m+p.nodeData[node+nVal]]
+		kv := p.kvSlice(p.nodeData[node])
+		rkey = kv[:p.nodeData[node+nKey]]
+		value = kv[p.nodeData[node+nKey]:][:p.nodeData[node+nVal]]
 	} else {
 		err = ErrNotFound
 	}


### PR DESCRIPTION
This PR makes memdb save skiplist nodes and kvs together in one byte-slice. The performance of memdb is significantly improved with this change(it's believed that the CPU cache hit-rate goes up).

benchmarks:

```bash
$ benchstat before.txt after.txt 
name         old time/op  new time/op  delta
Put-8        1.08µs ± 1%  0.98µs ± 1%   -9.11%  (p=0.008 n=5+5)
PutRandom-8  1.86µs ± 1%  1.52µs ± 2%  -17.94%  (p=0.008 n=5+5)
Get-8        1.24µs ± 1%  1.12µs ± 1%  -10.26%  (p=0.008 n=5+5)
GetRandom-8  2.06µs ± 1%  1.67µs ± 1%  -19.01%  (p=0.008 n=5+5)
```