### PR TITLE
leveldb: reduce compaction table set of target level

### DIFF
--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -516,10 +516,16 @@ func (p *versionStaging) finish(trivial bool) *version {
 					index := nt.searchNumLess(added[len(added)-1].fd.Num)
 					nt = append(nt[:index], append(added, nt[index:]...)...)
 				} else {
+					imin, imax := added.getRange(p.base.s.icmp)
+					i1 := nt.searchMin(p.base.s.icmp, imin)
+					i2 := nt.searchMin(p.base.s.icmp, imax)
+
+					// join with overlaps, and sort
+					added = append(added, nt[i1:i2]...)
 					added.sortByKey(p.base.s.icmp)
-					_, amax := added.getRange(p.base.s.icmp)
-					index := nt.searchMin(p.base.s.icmp, amax)
-					nt = append(nt[:index], append(added, nt[index:]...)...)
+
+					added = append(added, nt[i2:]...)
+					nt = append(nt[:i1], added...)
 				}
 				nv.levels[level] = nt
 				continue


### PR DESCRIPTION
During table compaction, tables in source & target level are simply merged together and output to new tables. That's fine for a testing-purpose random dataset. But for a real case, sometimes none of keys in source level falls within some target level tables(L0->L1, especially) . Then these target level tables can be skipped.

This PR implements this feature. 

Grepping the db log of my project with 'reducing' shows

```
16:07:47.800017 table@compaction reducing L0 -> L1 F·-27 S·-86MiB
16:07:57.902166 table@compaction reducing L0 -> L1 F·-7 S·-28MiB
16:08:18.274260 table@compaction reducing L2 -> L3 F·-2 S·-819B
16:08:19.743393 table@compaction reducing L2 -> L3 F·-4 S·-10KiB
16:08:20.480615 table@compaction reducing L2 -> L3 F·-3 S·-1MiB
```
