### PR TITLE
fix user-define comparer in getOverlaps

### DIFF
--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -7,7 +7,6 @@
 package leveldb
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
 	"sync/atomic"
@@ -208,7 +207,7 @@ func (tf tFiles) getOverlaps(dst tFiles, icmp *iComparer, umin, umax []byte, ove
 			index := tf.searchMinUkey(icmp, umin)
 			if index == 0 {
 				begin = 0
-			} else if bytes.Compare(tf[index-1].imax.ukey(), umin) >= 0 {
+			} else if icmp.uCompare(tf[index-1].imax.ukey(), umin) >= 0 {
 				// The min ukey overlaps with the index-1 file, expand it.
 				begin = index - 1
 			} else {
@@ -220,7 +219,7 @@ func (tf tFiles) getOverlaps(dst tFiles, icmp *iComparer, umin, umax []byte, ove
 			index := tf.searchMaxUkey(icmp, umax)
 			if index == len(tf) {
 				end = len(tf)
-			} else if bytes.Compare(tf[index].imin.ukey(), umax) <= 0 {
+			} else if icmp.uCompare(tf[index].imin.ukey(), umax) <= 0 {
 				// The max ukey overlaps with the index file, expand it.
 				end = index + 1
 			} else {


### PR DESCRIPTION
I pass a comparer to `opt.Option` with reverse alphabetical order, and insert db in the same order,
here is the test code:
```go

type cmp struct {
}

func (c *cmp) Compare(a, b []byte) int {
        // notice the reverse order
	return bytes.Compare(b, a)
}

func (c *cmp) Name() string {
	return "test"
}

func (c *cmp) Separator(dst, a, b []byte) []byte {
	return nil
}

func (c *cmp) Successor(dst, b []byte) []byte {
	return nil
}

func TestDD(t *testing.T) {
	db, err := OpenFile("testdb", &opt.Options{
		Comparer: new(cmp),
		NoSync:   true,
	})
	if err != nil {
		t.Fatal(err)
	}
	t1 := time.Now()
	for i := 10000000; i > 0; i-- {
		key := []byte(fmt.Sprintf("%20d", i))
		value := make([]byte, 128)
		rand.Read(value)
		db.Put(key, value, nil)
	}
}
```
Theoretically, there are no overlapped keys, and no compaction except trivial move should happen, but I still see lots of compactions in the LOG, finally I find two `bytes.Compare` in the code, hence this fix.